### PR TITLE
chore: add dual license to all package.json

### DIFF
--- a/blank_project/package.json
+++ b/blank_project/package.json
@@ -1,6 +1,7 @@
 {
   "name": "near-blank-project",
   "version": "0.0.1",
+  "license": "UNLICENSED",
   "scripts": {
     "build": "npm run build:contract && npm run build:web",
     "build:contract": "node asconfig.js",

--- a/blank_react_project/package.json
+++ b/blank_react_project/package.json
@@ -1,6 +1,7 @@
 {
   "name": "near-blank-project",
   "version": "0.1.0",
+  "license": "UNLICENSED",
   "scripts": {
     "build": "npm run build:contract && npm run build:web",
     "build:contract": "node asconfig.js",

--- a/blank_rust_project/package.json
+++ b/blank_rust_project/package.json
@@ -1,6 +1,7 @@
 {
   "name": "near-blank-project",
   "version": "0.0.1",
+  "license": "UNLICENSED",
   "scripts": {
     "build": "npm run build:contract && npm run build:web",
     "build:contract": "node ./contract/build",

--- a/blank_rust_react_project/package.json
+++ b/blank_rust_react_project/package.json
@@ -1,6 +1,7 @@
 {
   "name": "near-blank-project",
   "version": "0.1.0",
+  "license": "UNLICENSED",
   "scripts": {
     "build": "npm run build:contract && npm run build:web",
     "build:contract": "node ./contract/build",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": "https://github.com/nearprotocol/create-near-app.git",
   "author": "Yifang Ma <yifang@nearprotocol.com>",
-  "license": "MIT",
+  "license": "(MIT AND Apache-2.0)",
   "keywords": [
     "nearprotocol",
     "near-protocol",


### PR DESCRIPTION
Partially addresses https://github.com/near/devx/issues/155

I've added a `license` line to the generated `package.json` files, as they did not have this line previously. However, I did not also add `LICENSE` or `LICENSE-APACHE` files to those repositories.

Do we want to generate projects with the same dual license that we use as our NEAR standard? Or should this change only be for the root `package.json`?