### PR TITLE
chore: replace nearprotocol.com with near.org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at social@nearprotocol.com. All
+reported by contacting the project team at social@near.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to NEAR
 
 NEAR welcomes help in many forms including development, code review, documentation improvements, and outreach.
-Please visit [the contribution overview](https://docs.nearprotocol.com/docs/contribution/contribution-overview) for more information.
+Please visit [the contribution overview](https://docs.near.org/docs/contribution/contribution-overview) for more information.
 
 ## Using Github issues and pull requests
 
@@ -11,7 +11,7 @@ Please include steps to reproduction, if reporting an error. Information on all 
 
 If there are verbosity flags available, please include those to offer as much information as possible.
 
-When opening a pull request, please use the typical open-source flow of forking the desired repository and opening a pull request from your forked repository. (More information on [technical contributions here](https://docs.nearprotocol.com/docs/contribution/technical-contribution).)
+When opening a pull request, please use the typical open-source flow of forking the desired repository and opening a pull request from your forked repository. (More information on [technical contributions here](https://docs.near.org/docs/contribution/technical-contribution).)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ create-near-app
 ===============
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/nearprotocol/create-near-app) 
 
-Quickly build apps backed by the [NEAR](https://nearprotocol.com) blockchain
+Quickly build apps backed by the [NEAR](https://near.org) blockchain
 
 
 Prerequisites
@@ -36,7 +36,7 @@ Follow the instructions in the README.md in the project you just created! 🚀
 Getting Help
 ============
 
-Check out our [documentation](https://docs.nearprotocol.com) or chat with us on [Discord](http://near.chat). We'd love to hear from you!
+Check out our [documentation](https://docs.near.org) or chat with us on [Discord](http://near.chat). We'd love to hear from you!
 
 License
 =======

--- a/blank_project/README.md
+++ b/blank_project/README.md
@@ -2,7 +2,7 @@
 <br />
 
 <p>
-<img src="https://nearprotocol.com/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
+<img src="https://near.org/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
 </p>
 
 <br />

--- a/blank_project/src/index.html
+++ b/blank_project/src/index.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
   <style>
     .App-header {
-      background-image: url('https://nearprotocol.com/wp-content/uploads/2019/03/illo-developers.svg');
+      background-image: url('https://near.org/wp-content/uploads/2019/03/illo-developers.svg');
       min-height: 100vh;
       display: flex;
       flex-direction: column;

--- a/blank_project/src/main.js
+++ b/blank_project/src/main.js
@@ -10,11 +10,11 @@ window.nearConfig = nearConfig;
 async function InitContract() {
     console.log('nearConfig', nearConfig);
 
-    // Initializing connection to the NEAR DevNet.
+    // Initializing connection to the NEAR testnet.
     window.near = await nearlib.connect(Object.assign({ deps: { keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore() } }, nearConfig));
 
-    // Initializing Wallet based Account. It can work with NEAR DevNet wallet that
-    // is hosted at https://wallet.nearprotocol.com
+    // Initializing Wallet based Account. It can work with NEAR testnet wallet that
+    // is hosted at https://wallet.testnet.near.org
     window.walletAccount = new nearlib.WalletAccount(window.near);
 
     // Getting the Account ID. If unauthorized yet, it's just empty string.

--- a/blank_react_project/README.md
+++ b/blank_react_project/README.md
@@ -2,7 +2,7 @@
 <br />
 
 <p>
-<img src="https://nearprotocol.com/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
+<img src="https://near.org/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
 </p>
 
 <br />

--- a/blank_react_project/src/App.css
+++ b/blank_react_project/src/App.css
@@ -1,5 +1,5 @@
 .App-header {
-  background-image: url('https://nearprotocol.com/wp-content/uploads/2019/03/illo-developers.svg');
+  background-image: url('https://near.org/wp-content/uploads/2019/03/illo-developers.svg');
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/blank_react_project/src/App.js
+++ b/blank_react_project/src/App.js
@@ -112,9 +112,9 @@ class App extends Component {
           >
             Learn React
           </a>
-          <p><span role="img" aria-label="net">🕸</span> <a className="App-link" href="https://nearprotocol.com">NEAR Website</a> <span role="img" aria-label="net">🕸</span>
+          <p><span role="img" aria-label="net">🕸</span> <a className="App-link" href="https://near.org">NEAR Website</a> <span role="img" aria-label="net">🕸</span>
           </p>
-          <p><span role="img" aria-label="book">📚</span><a className="App-link" href="https://docs.nearprotocol.com"> Learn from NEAR Documentation</a> <span role="img" aria-label="book">📚</span>
+          <p><span role="img" aria-label="book">📚</span><a className="App-link" href="https://docs.near.org"> Learn from NEAR Documentation</a> <span role="img" aria-label="book">📚</span>
           </p>
         </div>
       </div>

--- a/blank_react_project/src/__snapshots__/App.test.js.snap
+++ b/blank_react_project/src/__snapshots__/App.test.js.snap
@@ -106,7 +106,7 @@ exports[`renders without crashing 1`] = `
        
       <a
         className="App-link"
-        href="https://nearprotocol.com"
+        href="https://near.org"
       >
         NEAR Website
       </a>
@@ -127,7 +127,7 @@ exports[`renders without crashing 1`] = `
       </span>
       <a
         className="App-link"
-        href="https://docs.nearprotocol.com"
+        href="https://docs.near.org"
       >
          Learn from NEAR Documentation
       </a>

--- a/blank_react_project/src/index.js
+++ b/blank_react_project/src/index.js
@@ -9,7 +9,7 @@ async function initContract() {
     window.nearConfig = getConfig(process.env.NODE_ENV || 'development')
     console.log("nearConfig", window.nearConfig);
 
-    // Initializing connection to the NEAR DevNet.
+    // Initializing connection to the NEAR testnet.
     window.near = await nearlib.connect(Object.assign({ deps: { keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore() } }, window.nearConfig));
     
     // Needed to access wallet login

--- a/blank_rust_project/README.md
+++ b/blank_rust_project/README.md
@@ -2,7 +2,7 @@
 <br />
 
 <p>
-<img src="https://nearprotocol.com/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
+<img src="https://near.org/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
 </p>
 
 <br />

--- a/blank_rust_project/src/index.html
+++ b/blank_rust_project/src/index.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
   <style>
     .App-header {
-      background-image: url('https://nearprotocol.com/wp-content/uploads/2019/03/illo-developers.svg');
+      background-image: url('https://near.org/wp-content/uploads/2019/03/illo-developers.svg');
       min-height: 100vh;
       display: flex;
       flex-direction: column;

--- a/blank_rust_project/src/main.js
+++ b/blank_rust_project/src/main.js
@@ -10,11 +10,11 @@ window.nearConfig = nearConfig;
 async function InitContract() {
     console.log('nearConfig', nearConfig);
 
-    // Initializing connection to the NEAR DevNet.
+    // Initializing connection to the NEAR testnet.
     window.near = await nearlib.connect(Object.assign({ deps: { keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore() } }, nearConfig));
 
-    // Initializing Wallet based Account. It can work with NEAR DevNet wallet that
-    // is hosted at https://wallet.nearprotocol.com
+    // Initializing Wallet based Account. It can work with NEAR testnet wallet that
+    // is hosted at https://wallet.testnet.near.org
     window.walletAccount = new nearlib.WalletAccount(window.near);
 
     // Getting the Account ID. If unauthorized yet, it's just empty string.

--- a/blank_rust_react_project/README.md
+++ b/blank_rust_react_project/README.md
@@ -2,7 +2,7 @@
 <br />
 
 <p>
-<img src="https://nearprotocol.com/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
+<img src="https://near.org/wp-content/themes/near-19/assets/img/logo.svg?t=1553011311" width="240">
 </p>
 
 <br />

--- a/blank_rust_react_project/src/App.css
+++ b/blank_rust_react_project/src/App.css
@@ -1,5 +1,5 @@
 .App-header {
-  background-image: url('https://nearprotocol.com/wp-content/uploads/2019/03/illo-developers.svg');
+  background-image: url('https://near.org/wp-content/uploads/2019/03/illo-developers.svg');
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/blank_rust_react_project/src/App.js
+++ b/blank_rust_react_project/src/App.js
@@ -112,9 +112,9 @@ class App extends Component {
           >
             Learn React
           </a>
-          <p><span role="img" aria-label="net">🕸</span> <a className="App-link" href="https://nearprotocol.com">NEAR Website</a> <span role="img" aria-label="net">🕸</span>
+          <p><span role="img" aria-label="net">🕸</span> <a className="App-link" href="https://near.org">NEAR Website</a> <span role="img" aria-label="net">🕸</span>
           </p>
-          <p><span role="img" aria-label="book">📚</span><a className="App-link" href="https://docs.nearprotocol.com"> Learn from NEAR Documentation</a> <span role="img" aria-label="book">📚</span>
+          <p><span role="img" aria-label="book">📚</span><a className="App-link" href="https://docs.near.org"> Learn from NEAR Documentation</a> <span role="img" aria-label="book">📚</span>
           </p>
         </div>
       </div>

--- a/blank_rust_react_project/src/__snapshots__/App.test.js.snap
+++ b/blank_rust_react_project/src/__snapshots__/App.test.js.snap
@@ -106,7 +106,7 @@ exports[`renders without crashing 1`] = `
        
       <a
         className="App-link"
-        href="https://nearprotocol.com"
+        href="https://near.org"
       >
         NEAR Website
       </a>
@@ -127,7 +127,7 @@ exports[`renders without crashing 1`] = `
       </span>
       <a
         className="App-link"
-        href="https://docs.nearprotocol.com"
+        href="https://docs.near.org"
       >
          Learn from NEAR Documentation
       </a>

--- a/blank_rust_react_project/src/index.js
+++ b/blank_rust_react_project/src/index.js
@@ -9,7 +9,7 @@ async function initContract() {
     window.nearConfig = getConfig(process.env.NODE_ENV || 'development')
     console.log("nearConfig", window.nearConfig);
 
-    // Initializing connection to the NEAR DevNet.
+    // Initializing connection to the NEAR testnet.
     window.near = await nearlib.connect(Object.assign({ deps: { keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore() } }, window.nearConfig));
     
     // Needed to access wallet login

--- a/contract/rust/Cargo.toml
+++ b/contract/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "status-message"
 version = "0.1.0"
-authors = ["Near Inc <hello@nearprotocol.com>"]
+authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "fix": "eslint . --fix"
   },
   "repository": "https://github.com/nearprotocol/create-near-app.git",
-  "author": "Yifang Ma <yifang@nearprotocol.com>",
+  "author": "Yifang Ma <yifang@near.org>",
   "license": "(MIT AND Apache-2.0)",
   "keywords": [
     "nearprotocol",


### PR DESCRIPTION
fixes near/devx#217

Using [ripgrep]:

* `for f in $(rg -l nearprotocol\.com); do sed -i '' 's/nearprotocol.com/near.org/' $f; done`
* `for f in $(rg -l DevNet); do sed -i '' 's/DevNet/testnet/' $f; done`
* `for f in $(rg -l wallet\.near\.org); do sed -i '' 's/wallet.near.org/wallet.testnet.near.org/' $f; done`

  [ripgrep]: https://github.com/BurntSushi/ripgrep