### PR TITLE
fix: rm obsolete --validate flag from asconfig

### DIFF
--- a/blank_project/asconfig.js
+++ b/blank_project/asconfig.js
@@ -6,7 +6,6 @@ compile("assembly/main.ts", // input file
         //   "-O1",          // Optional arguments
         "--debug",
         "--measure",         // Shows compiler runtime
-        "--validate"         // Validate the generated wasm module
         ], {
           verbose: true     // Output the cli args passed to asc
         });

--- a/blank_project/package.json
+++ b/blank_project/package.json
@@ -19,7 +19,7 @@
     "gh-pages": "^3.0.0",
     "jest": "^26.0.1",
     "jest-environment-node": "^26.0.0",
-    "near-sdk-as": "^0.4.1",
+    "near-sdk-as": "^0.4.2",
     "near-shell": "^0.24.4",
     "nodemon": "^2.0.3",
     "parcel-bundler": "^1.12.4",

--- a/blank_react_project/asconfig.js
+++ b/blank_react_project/asconfig.js
@@ -6,7 +6,6 @@ compile("assembly/main.ts", // input file
         //   "-O1",          // Optional arguments
         "--debug",
         "--measure",         // Shows compiler runtime
-        "--validate"         // Validate the generated wasm module
         ], {
           verbose: true     // Output the cli args passed to asc
         });

--- a/blank_react_project/package.json
+++ b/blank_react_project/package.json
@@ -22,7 +22,7 @@
     "gh-pages": "^3.0.0",
     "jest": "^26.0.1",
     "jest-environment-node": "^26.0.0",
-    "near-sdk-as": "^0.4.1",
+    "near-sdk-as": "^0.4.2",
     "near-shell": "^0.24.4",
     "nodemon": "^2.0.3",
     "parcel-bundler": "^1.12.4",


### PR DESCRIPTION
This was removed in [v10.0.0](https://github.com/AssemblyScript/assemblyscript/releases/tag/v0.10.0)

We have been using this version since at least 1dd59324cfc779becf9e5ee1127925ad8b89adfc