### PR TITLE
feat: use current networkId in notification

### DIFF
--- a/common/frontend/config.js
+++ b/common/frontend/config.js
@@ -15,7 +15,7 @@ function getConfig(env) {
   case 'development':
   case 'testnet':
     return {
-      networkId: 'default',
+      networkId: 'testnet',
       nodeUrl: 'https://rpc.testnet.near.org',
       contractName: CONTRACT_NAME,
       walletUrl: 'https://wallet.testnet.near.org',

--- a/templates/react/src/App.js
+++ b/templates/react/src/App.js
@@ -3,6 +3,9 @@ import React from 'react'
 import { login, logout, onSubmit } from './utils'
 import './global.css'
 
+import getConfig from './config'
+const { networkId } = getConfig(process.env.NODE_ENV || 'development')
+
 export default function App() {
   // use React Hooks to store greeting in component state
   const [greeting, setGreeting] = React.useState()
@@ -149,7 +152,7 @@ export default function App() {
 
 // this component gets rendered by App after the form is submitted
 function Notification() {
-  const urlPrefix = 'https://explorer.testnet.near.org/accounts'
+  const urlPrefix = `https://explorer.${networkId}.near.org/accounts`
   return (
     <aside>
       <a target="_blank" href={`${urlPrefix}/${window.accountId}`}>

--- a/templates/vanilla/src/main.js
+++ b/templates/vanilla/src/main.js
@@ -2,6 +2,9 @@ import 'regenerator-runtime/runtime'
 
 import { initContract, login, logout, onSubmit } from './utils'
 
+import getConfig from './config'
+const { networkId } = getConfig(process.env.NODE_ENV || 'development')
+
 // global variable used throughout
 let currentGreeting
 
@@ -55,6 +58,10 @@ function signedInFlow() {
   const contractLink = document.querySelector('[data-behavior=notification] a:nth-of-type(2)')
   contractLink.href = contractLink.href + window.contract.contractId
   contractLink.innerText = '@' + window.contract.contractId
+
+  // update with selected networkId
+  accountLink.href = accountLink.href.replace('testnet', networkId)
+  contractLink.href = contractLink.href.replace('testnet', networkId)
 
   fetchGreeting()
 }


### PR DESCRIPTION
this was missed in #372

in the notification that links people to NEAR Explorer, we need to link
to the version of explorer for their selected network. This way, if
someone runs their new app on betanet, the links in the notification
don't lead to 404 pages.