### PR TITLE
feat: rapid development for create-near-app itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tmp-project
 .env.test.local
 .env.production.local
 .idea
+/templates/**/yarn.lock
 
 npm-debug.log*
 yarn-debug.log*

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+templates/*/assembly
+templates/*/contract
+templates/*/package.json
+templates/*/src/assets
+templates/*/src/config.js
+templates/*/src/global.css
+templates/*/src/utils.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - yarn
 git:
   autocrlf: false
+  symlinks: true
 script:
   - yarn test
   - yarn lint

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Getting Help
 
 Check out our [documentation](https://docs.near.org) or chat with us on [Discord](http://near.chat). We'd love to hear from you!
 
+
+Contributing
+============
+
+To make changes to `create-near-app` itself:
+
+* clone the repository
+* in your terminal, enter one of the folders inside `templates`, such as `templates/vanilla`
+* now you can run `yarn` to install dependencies and `yarn dev` to run the local development server, just like you can in a new app created with `create-near-app`
+
+
 License
 =======
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.9.3",
   "description": "generate new near blank project with different type",
   "main": "index.js",
+  "files": [
+      "/common",
+      "/templates"
+  ],
   "scripts": {
     "test": "node ./test/test-new-project.js",
     "lint": "eslint .",
@@ -29,12 +33,12 @@
     "cross-spawn": "^7.0.1",
     "ncp": "^2.0.0",
     "replace-in-files": "^2.0.3",
+    "shelljs": "^0.8.3",
     "which": "^2.0.2",
     "yargs": "^15.0.2"
   },
   "devDependencies": {
-    "eslint": "^7.0.0",
-    "shelljs": "^0.8.3"
+    "eslint": "^7.0.0"
   },
   "engines": {
     "node": ">=12"

--- a/templates/react/assembly
+++ b/templates/react/assembly
@@ -1,0 +1,1 @@
+../../common/contracts/asc

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -1,0 +1,1 @@
+packagejsons/asc/package.json

--- a/templates/react/src/assets
+++ b/templates/react/src/assets
@@ -1,0 +1,1 @@
+../../../common/frontend/assets

--- a/templates/react/src/config.js
+++ b/templates/react/src/config.js
@@ -1,0 +1,1 @@
+../../../common/frontend/config.js

--- a/templates/react/src/global.css
+++ b/templates/react/src/global.css
@@ -1,0 +1,1 @@
+../../../common/frontend/global.css

--- a/templates/react/src/utils.js
+++ b/templates/react/src/utils.js
@@ -1,0 +1,1 @@
+../../../common/frontend/utils.js

--- a/templates/vanilla/assembly
+++ b/templates/vanilla/assembly
@@ -1,0 +1,1 @@
+../../common/contracts/asc

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -1,0 +1,1 @@
+packagejsons/asc/package.json

--- a/templates/vanilla/src/assets
+++ b/templates/vanilla/src/assets
@@ -1,0 +1,1 @@
+../../../common/frontend/assets

--- a/templates/vanilla/src/config.js
+++ b/templates/vanilla/src/config.js
@@ -1,0 +1,1 @@
+../../../common/frontend/config.js

--- a/templates/vanilla/src/global.css
+++ b/templates/vanilla/src/global.css
@@ -1,0 +1,1 @@
+../../../common/frontend/global.css

--- a/templates/vanilla/src/utils.js
+++ b/templates/vanilla/src/utils.js
@@ -1,0 +1,1 @@
+../../../common/frontend/utils.js


### PR DESCRIPTION
Previously, in order to make changes to one of the templates in
create-near-app, the development process looked something like:

1. use create-near-app to generate a new app
2. fix bugs or make improvements in the new app
3. backport the changes to create-near-app proper

This is error-prone and slow, and makes it hard for people new to
create-near-app to submit improvements.

Instead, this change makes it possible to switch right into a template
directory and start working:

1. `cd templates/vanilla` or `cd templates/react`
2. run `yarn`, `yarn test`, `yarn dev`, or whatever. Make changes.

Now your changes are immediately reflected to the correct file in
the `create-near-app` repo with no backporting. And when you actually
use `create-near-app` to create a new project, the symlinks and project
build files (like node_modules) do not get copied over. To aid
troubleshooting these more complex copy functions, a new
`--very-verbose` switch has been added, which prints out every specific
file that is copied and skipped.

This also sets up a `files` directive in `package.json` and a new
`.npmignore` file in order to safely ignore these symlinks, to avoid
causing problems for Windows users who don't have symlinks & git
configured properly.