### PR TITLE
fix: catch error on setGreeting

### DIFF
--- a/common/frontend/utils.js
+++ b/common/frontend/utils.js
@@ -35,17 +35,23 @@ export async function onSubmit(event) {
   // disable the form while the value gets updated on-chain
   fieldset.disabled = true
 
-  // make an update call to the smart contract
-  await contract.setGreeting({
-    // pass the value that the user entered in the greeting field
-    message: greeting.value
-  })
-
-  // re-enable the form
-  fieldset.disabled = false
-
-  // disable the save button, since it now matches the persisted value
-  document.querySelector('form button').disabled = true
+  try {
+    // make an update call to the smart contract
+    await contract.setGreeting({
+      // pass the value that the user entered in the greeting field
+      message: greeting.value
+    })
+  } catch (e) {
+    alert(
+      'Something went wrong! ' +
+      'Maybe you need to sign out and back in? ' +
+      'Check your browser console for more info.'
+    );
+    throw e;
+  } finally {
+    // re-enable the form, whether the call succeeded or failed
+    fieldset.disabled = false
+  }
 }
 
 export function logout() {

--- a/templates/vanilla/src/main.js
+++ b/templates/vanilla/src/main.js
@@ -8,10 +8,15 @@ const { networkId } = getConfig(process.env.NODE_ENV || 'development')
 // global variable used throughout
 let currentGreeting
 
+const submitButton = document.querySelector('form button')
+
 document.querySelector('form').onsubmit = async (event) => {
   // fire frontend-agnostic submit behavior, including data persistence
   // look in utils.js to see how this updates data on-chain!
   await onSubmit(event)
+
+  // disable the save button, since it now matches the persisted value
+  submitButton.disabled = true
 
   // update the greeting in the UI
   await fetchGreeting()
@@ -27,7 +32,6 @@ document.querySelector('form').onsubmit = async (event) => {
 }
 
 document.querySelector('input#greeting').oninput = (event) => {
-  const submitButton = document.querySelector('form button')
   if (event.target.value !== currentGreeting) {
     submitButton.disabled = false
   } else {


### PR DESCRIPTION
I recommend reviewing the code [with indentation changes hidden](https://github.com/near/create-near-app/pull/398/files?diff=unified&w=1)

Fixes #391 by moving button disabling to vanilla/src/main.js, as this logic interferes with React's state management and breaks the React app

Fixes #397 (also fixes #70) by adding error handling to the setGreeting and moving form reenabling to the `finally` clause of the promise resolution