### PR TITLE
README.md: adding a note about `yarn create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You can configure two main aspects of your new NEAR project:
 | `npx create-near-app --rust new-awesome-app`           | React      | Rust           |
 | `npx create-near-app --vanilla --rust new-awesome-app` | vanilla JS | Rust           |
 
+You can also use **yarn** instead of `npx`:
+
+    yarn create near-app [options] new-awesome-app
+
 
 Develop your own Dapp
 =====================


### PR DESCRIPTION
README.md clearly describes how to use `npx`, but doesn't provide an example with Yarn.
This PR adds a note about Yarn usage in Getting Started.