### PR TITLE
fix(requestSignIn): rm obsolete app name parameter

### DIFF
--- a/common/frontend/utils.js
+++ b/common/frontend/utils.js
@@ -61,10 +61,9 @@ export function logout() {
 }
 
 export function login() {
-  window.walletConnection.requestSignIn(
-    // The contract name that would be authorized to be called by the user's account.
-    nearConfig.contractName,
-    // This is the app name. It can be anything.
-    'Welcome to NEAR'
-  )
+  // Allow the current app to make calls to the specified contract on the
+  // user's behalf.
+  // This works by creating a new access key for the user's account and storing
+  // the private key in localStorage.
+  window.walletConnection.requestSignIn(nearConfig.contractName)
 }


### PR DESCRIPTION
This parameter is no longer used by NEAR Wallet: https://github.com/near/near-wallet/pull/725

This also adds more info to the comment to hopefully guide people toward a more precise understanding of what "signing in" means