### PR TITLE
refactor(contracts): simplify & add comments

### DIFF
--- a/common/contracts/assemblyscript/main.ts
+++ b/common/contracts/assemblyscript/main.ts
@@ -1,14 +1,40 @@
-// smart contract source code, written in AssemblyScript
-// for more info: https://docs.near.org/docs/roles/developer/contracts/assemblyscript
+/*
+ * This is an example of an AssemblyScript smart contract with two simple,
+ * symmetric functions:
+ *
+ * 1. setGreeting: accepts a greeting, such as "howdy", and records it for the
+ *    user (account_id) who sent the request
+ * 2. getGreeting: accepts an account_id and returns the greeting saved for it,
+ *    defaulting to "Hello"
+ *
+ * Learn more about writing NEAR smart contracts with AssemblyScript:
+ * https://docs.near.org/docs/roles/developer/contracts/assemblyscript
+ *
+ */
 
-import { Context, storage } from "near-sdk-as";
+import { Context, logging, storage } from "near-sdk-as";
 
 const DEFAULT_MESSAGE = "Hello"
 
+// Exported functions will be part of the public interface for your smart contract.
+// Feel free to extract behavior to non-exported functions!
 export function getGreeting(accountId: string): string | null {
+  // This uses raw `storage.get`, a low-level way to interact with on-chain
+  // storage for simple contracts.
+  // If you have something more complex, check out persistent collections:
+  // https://docs.near.org/docs/roles/developer/contracts/assemblyscript#imports
   return storage.get<string>(accountId, DEFAULT_MESSAGE);
 }
 
 export function setGreeting(message: string): void {
-  storage.set(Context.sender, message);
+  const account_id = Context.sender;
+
+  // Use logging.log to record logs permanently to the blockchain!
+  logging.log(
+    // String interpolation (`like ${this}`) is a work in progress:
+    // https://github.com/AssemblyScript/assemblyscript/pull/1115
+    'Saving greeting "' + message + '" for account "' + account_id + '"'
+  );
+
+  storage.set(account_id, message);
 }

--- a/common/contracts/rust/Cargo.lock
+++ b/common/contracts/rust/Cargo.lock
@@ -130,6 +130,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "greeter"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "near-sdk",
+ "serde",
+ "serde_json",
+ "wee_alloc",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,17 +404,6 @@ dependencies = [
  "digest",
  "keccak",
  "opaque-debug",
-]
-
-[[package]]
-name = "status-message"
-version = "0.1.0"
-dependencies = [
- "borsh",
- "near-sdk",
- "serde",
- "serde_json",
- "wee_alloc",
 ]
 
 [[package]]

--- a/common/contracts/rust/Cargo.toml
+++ b/common/contracts/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "status-message"
+name = "greeter"
 version = "0.1.0"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"

--- a/common/contracts/rust/build.js
+++ b/common/contracts/rust/build.js
@@ -6,4 +6,4 @@ shell.cd('contract');
 // Note: see flags in ./cargo/config
 shell.exec('cargo build --target wasm32-unknown-unknown --release');
 shell.mkdir('-p', '../out');
-shell.cp('./target/wasm32-unknown-unknown/release/status_message.wasm', '../out/main.wasm');
+shell.cp('./target/wasm32-unknown-unknown/release/greeter.wasm', '../out/main.wasm');

--- a/common/contracts/rust/src/lib.rs
+++ b/common/contracts/rust/src/lib.rs
@@ -1,6 +1,17 @@
-// smart contract source code, written in Rust
-// for more info: https://docs.near.org/docs/roles/developer/contracts/near-sdk-rs
+/*
+ * This is an example of a Rust smart contract with two simple, symmetric functions:
+ *
+ * 1. set_greeting: accepts a greeting, such as "howdy", and records it for the user (account_id)
+ *    who sent the request
+ * 2. get_greeting: accepts an account_id and returns the greeting saved for it, defaulting to
+ *    "Hello"
+ *
+ * Learn more about writing NEAR smart contracts with Rust:
+ * https://github.com/near/near-sdk-rs
+ *
+ */
 
+// To conserve gas, efficient serialization is achieved through Borsh (http://borsh.io/)
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::{env, near_bindgen};
 use std::collections::HashMap;
@@ -8,6 +19,8 @@ use std::collections::HashMap;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+// Structs in Rust are similar to other languages, and may include impl keyword as shown below
+// Note: the names of the structs are not important when calling the smart contract, but the function names are
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
 pub struct Welcome {
@@ -18,26 +31,42 @@ pub struct Welcome {
 impl Welcome {
     pub fn set_greeting(&mut self, message: String) {
         let account_id = env::signer_account_id();
+
+        // Use env::log to record logs permanently to the blockchain!
+        env::log(format!("Saving greeting '{}' for account '{}'", message, account_id,).as_bytes());
+
         self.records.insert(account_id, message);
     }
 
+    // `match` is similar to `switch` in other languages; here we use it to default to "Hello" if
+    // self.records.get(&account_id) is not yet defined.
+    // Learn more: https://doc.rust-lang.org/book/ch06-02-match.html#matching-with-optiont
     pub fn get_greeting(&self, account_id: String) -> &str {
         match self.records.get(&account_id) {
-            None => {
-                env::log(b"Using default message.");
-                "Hello"
-            }
-            _ => self.records.get(&account_id).unwrap(),
+            Some(greeting) => greeting,
+            None => "Hello",
         }
     }
 }
 
+/*
+ * The rest of this file holds the inline tests for the code above
+ * Learn more about Rust tests: https://doc.rust-lang.org/book/ch11-01-writing-tests.html
+ *
+ * To run from contract directory:
+ * cargo test -- --nocapture
+ *
+ * From project root, to run in combination with frontend tests:
+ * yarn test
+ *
+ */
 #[cfg(test)]
 mod tests {
     use super::*;
     use near_sdk::MockedBlockchain;
     use near_sdk::{testing_env, VMContext};
 
+    // mock the context for testing, notice "signer_account_id" that was accessed above from env::
     fn get_context(input: Vec<u8>, is_view: bool) -> VMContext {
         VMContext {
             current_account_id: "alice_near".to_string(),
@@ -60,7 +89,7 @@ mod tests {
     }
 
     #[test]
-    fn set_get_message() {
+    fn set_then_get_greeting() {
         let context = get_context(vec![], false);
         testing_env!(context);
         let mut contract = Welcome::default();
@@ -72,10 +101,11 @@ mod tests {
     }
 
     #[test]
-    fn get_nonexistent_message() {
+    fn get_default_greeting() {
         let context = get_context(vec![], true);
         testing_env!(context);
         let contract = Welcome::default();
+        // this test did not call set_greeting so should return the default "Hello" greeting
         assert_eq!(
             "Hello".to_string(),
             contract.get_greeting("francis.near".to_string())

--- a/templates/react/packagejsons/rust/package.json
+++ b/templates/react/packagejsons/rust/package.json
@@ -13,7 +13,7 @@
     "prestart": "npm run build:contract && npm run dev:deploy:contract",
     "start": "echo The app is starting! It will automatically open in your browser when ready && env-cmd -f ./neardev/dev-account.env parcel src/index.html --open",
     "dev": "nodemon --watch assembly -e ts --exec \"npm run start\"",
-    "test": "(cd contract && cargo test --package status-message -- --nocapture && cd ..) && npm run build:contract && jest test --runInBand"
+    "test": "(cd contract && cargo test -- --nocapture && cd ..) && npm run build:contract && jest test --runInBand"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.9.5",

--- a/templates/vanilla/packagejsons/rust/package.json
+++ b/templates/vanilla/packagejsons/rust/package.json
@@ -13,7 +13,7 @@
     "prestart": "npm run build:contract && npm run dev:deploy:contract",
     "start": "echo The app is starting! It will automatically open in your browser when ready && env-cmd -f ./neardev/dev-account.env parcel src/index.html --open",
     "dev": "nodemon --watch assembly -e ts --exec \"npm run start\"",
-    "test": "(cd contract && cargo test --package status-message -- --nocapture && cd ..) && npm run build:contract && jest test --runInBand"
+    "test": "(cd contract && cargo test -- --nocapture && cd ..) && npm run build:contract && jest test --runInBand"
   },
   "devDependencies": {
     "gh-pages": "^3.0.0",


### PR DESCRIPTION
A redo of https://github.com/near/create-near-app/pull/101, which had
good stuff but targeted a very different version of create-near-app

Things that might not be super obvious from just reading the new
comments:

* rename rust project from "status-message", which had nothing to do
  with this project, to "greeter"
* remove superfluous references to contract name (`--package` stuff)
* move `env::log` to `set_greeting`, making it easier to find in NEAR Explorer
* Simplify `match` expression