### PR TITLE
Use near-cli instead of near-shell

### DIFF
--- a/common/contracts/assemblyscript/README.md
+++ b/common/contracts/assemblyscript/README.md
@@ -41,12 +41,12 @@ Deploy
 Every smart contract in NEAR has its [own associated account][NEAR accounts]. When you run `npm run dev`, your smart contract gets deployed to the live NEAR TestNet with a throwaway account. When you're ready to make it permanent, here's how.
 
 
-Step 0: Install near-shell (optional)
+Step 0: Install near-cli (optional)
 -------------------------------------
 
-[near-shell] is a command line interface (CLI) for interacting with the NEAR blockchain. It was installed to the local `node_modules` folder when you ran `npm install`, but for best ergonomics you may want to install it globally:
+[near-cli] is a command line interface (CLI) for interacting with the NEAR blockchain. It was installed to the local `node_modules` folder when you ran `npm install`, but for best ergonomics you may want to install it globally:
 
-    npm install --global near-shell
+    npm install --global near-cli
 
 Or, if you'd rather use the locally-installed version, you can prefix all `near` commands with `npx`
 
@@ -58,7 +58,7 @@ Step 1: Create an account for the contract
 
 Each account on NEAR can have at most one contract deployed to it. If you've already created an account such as `your-name.testnet`, you can deploy your contract to `near-blank-project.your-name.testnet`. Assuming you've already created an account on [NEAR Wallet], here's how to create `near-blank-project.your-name.testnet`:
 
-1. Authorize NEAR shell, following the commands it gives you:
+1. Authorize NEAR CLI, following the commands it gives you:
 
       near login
 
@@ -102,5 +102,5 @@ On Windows, if you're seeing an error containing `EPERM` it may be related to sp
   [jest]: https://jestjs.io/
   [NEAR accounts]: https://docs.near.org/docs/concepts/account
   [NEAR Wallet]: https://wallet.testnet.near.org/
-  [near-shell]: https://github.com/near/near-shell
+  [near-cli]: https://github.com/near/near-cli
   [gh-pages]: https://github.com/tschaub/gh-pages

--- a/common/contracts/rust/README.md
+++ b/common/contracts/rust/README.md
@@ -41,12 +41,12 @@ Deploy
 Every smart contract in NEAR has its [own associated account][NEAR accounts]. When you run `npm run dev`, your smart contract gets deployed to the live NEAR TestNet with a throwaway account. When you're ready to make it permanent, here's how.
 
 
-Step 0: Install near-shell (optional)
+Step 0: Install near-cli (optional)
 -------------------------------------
 
-[near-shell] is a command line interface (CLI) for interacting with the NEAR blockchain. It was installed to the local `node_modules` folder when you ran `npm install`, but for best ergonomics you may want to install it globally:
+[near-cli] is a command line interface (CLI) for interacting with the NEAR blockchain. It was installed to the local `node_modules` folder when you ran `npm install`, but for best ergonomics you may want to install it globally:
 
-    npm install --global near-shell
+    npm install --global near-cli
 
 Or, if you'd rather use the locally-installed version, you can prefix all `near` commands with `npx`
 
@@ -58,7 +58,7 @@ Step 1: Create an account for the contract
 
 Each account on NEAR can have at most one contract deployed to it. If you've already created an account such as `your-name.testnet`, you can deploy your contract to `near-blank-project.your-name.testnet`. Assuming you've already created an account on [NEAR Wallet], here's how to create `near-blank-project.your-name.testnet`:
 
-1. Authorize NEAR shell, following the commands it gives you:
+1. Authorize NEAR CLI, following the commands it gives you:
 
       near login
 
@@ -103,5 +103,5 @@ On Windows, if you're seeing an error containing `EPERM` it may be related to sp
   [jest]: https://jestjs.io/
   [NEAR accounts]: https://docs.near.org/docs/concepts/account
   [NEAR Wallet]: https://wallet.testnet.near.org/
-  [near-shell]: https://github.com/near/near-shell
+  [near-cli]: https://github.com/near/near-cli
   [gh-pages]: https://github.com/tschaub/gh-pages

--- a/templates/react/packagejsons/assemblyscript/package.json
+++ b/templates/react/packagejsons/assemblyscript/package.json
@@ -25,7 +25,7 @@
     "jest": "^26.0.1",
     "jest-environment-node": "^26.0.0",
     "near-sdk-as": "^0.5.0",
-    "near-shell": "^0.24.9",
+    "near-cli": "^1.0.1",
     "nodemon": "^2.0.3",
     "parcel-bundler": "^1.12.4",
     "react-test-renderer": "^16.13.1"
@@ -44,7 +44,7 @@
     "setupFiles": [
       "<rootDir>/src/jest.init.js"
     ],
-    "testEnvironment": "near-shell/test_environment",
+    "testEnvironment": "near-cli/test_environment",
     "testPathIgnorePatterns": [
       "<rootDir>/assembly/",
       "<rootDir>/node_modules/"

--- a/templates/react/packagejsons/rust/package.json
+++ b/templates/react/packagejsons/rust/package.json
@@ -22,7 +22,7 @@
     "gh-pages": "^3.0.0",
     "jest": "^26.0.1",
     "jest-environment-node": "^26.0.0",
-    "near-shell": "^0.24.9",
+    "near-cli": "^1.0.1",
     "nodemon": "^2.0.3",
     "parcel-bundler": "^1.12.4",
     "react-test-renderer": "^16.13.1",
@@ -43,7 +43,7 @@
     "setupFiles": [
       "<rootDir>/src/jest.init.js"
     ],
-    "testEnvironment": "near-shell/test_environment",
+    "testEnvironment": "near-cli/test_environment",
     "testPathIgnorePatterns": [
       "<rootDir>/assembly/",
       "<rootDir>/node_modules/"

--- a/templates/react/src/main.test.js
+++ b/templates/react/src/main.test.js
@@ -1,5 +1,5 @@
 beforeAll(async function () {
-  // NOTE: nearlib and nearConfig are made available by near-shell/test_environment
+  // NOTE: nearlib and nearConfig are made available by near-cli/test_environment
   const near = await nearlib.connect(nearConfig)
   window.accountId = nearConfig.contractName
   window.contract = await near.loadContract(nearConfig.contractName, {

--- a/templates/react/src/wallet/login/index.html
+++ b/templates/react/src/wallet/login/index.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
 </head>
 <body style="background: #fff; margin-top: 3em">
-  <div>For local account login, Please run the following command in shell, then enter account id here.
+  <div>For local account login, Please run the following command in NEAR CLI, then enter account id here.
   </div>
   <div>
       <code id="shell-command"></code>

--- a/templates/vanilla/packagejsons/assemblyscript/package.json
+++ b/templates/vanilla/packagejsons/assemblyscript/package.json
@@ -20,7 +20,7 @@
     "jest": "^26.0.1",
     "jest-environment-node": "^26.0.0",
     "near-sdk-as": "^0.5.0",
-    "near-shell": "^0.24.9",
+    "near-cli": "^1.0.1",
     "nodemon": "^2.0.3",
     "parcel-bundler": "^1.12.4",
     "env-cmd": "^10.1.0"
@@ -30,7 +30,7 @@
     "regenerator-runtime": "^0.13.5"
   },
   "jest": {
-    "testEnvironment": "near-shell/test_environment",
+    "testEnvironment": "near-cli/test_environment",
     "testPathIgnorePatterns": [
       "<rootDir>/assembly/",
       "<rootDir>/node_modules/"

--- a/templates/vanilla/packagejsons/rust/package.json
+++ b/templates/vanilla/packagejsons/rust/package.json
@@ -19,7 +19,7 @@
     "gh-pages": "^3.0.0",
     "jest": "^26.0.1",
     "jest-environment-node": "^26.0.0",
-    "near-shell": "^0.24.9",
+    "near-cli": "^1.0.1",
     "nodemon": "^2.0.3",
     "parcel-bundler": "^1.12.4",
     "env-cmd": "^10.1.0",
@@ -30,7 +30,7 @@
     "regenerator-runtime": "^0.13.5"
   },
   "jest": {
-    "testEnvironment": "near-shell/test_environment",
+    "testEnvironment": "near-cli/test_environment",
     "testPathIgnorePatterns": [
       "<rootDir>/assembly/",
       "<rootDir>/node_modules/"

--- a/templates/vanilla/src/main.test.js
+++ b/templates/vanilla/src/main.test.js
@@ -1,5 +1,5 @@
 beforeAll(async function () {
-  // NOTE: nearlib and nearConfig are made available by near-shell/test_environment
+  // NOTE: nearlib and nearConfig are made available by near-cli/test_environment
   const near = await nearlib.connect(nearConfig)
   window.accountId = nearConfig.contractName
   window.contract = await near.loadContract(nearConfig.contractName, {

--- a/templates/vanilla/src/wallet/login/index.html
+++ b/templates/vanilla/src/wallet/login/index.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
 </head>
 <body style="background: #fff; margin-top: 3em">
-  <div>Please run the following command in shell, then enter account id here. masterAccountId default: test.near
+  <div>Please run the following command in NEAR CLI, then enter account id here. masterAccountId default: test.near
   </div>
   <div>
       <code id="shell-command"></code>


### PR DESCRIPTION
We're now using
https://www.npmjs.com/package/near-cli
and have a deprecation warning at the top of:
https://www.npmjs.com/package/near-shell

Also the Github has been renamed to:
https://github.com/near/near-cli