### PR TITLE
feat: add overflow-checks to Rust release profile

### DIFF
--- a/common/contracts/rust/Cargo.toml
+++ b/common/contracts/rust/Cargo.toml
@@ -17,6 +17,8 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
+# Opt into extra safety checks on arithmetic operations https://stackoverflow.com/a/64136471/249801
+overflow-checks = true
 
 [workspace]
 members = []


### PR DESCRIPTION
Fixes #498 

By default, Rust has overflow checks enabled for debug builds, but disabled in optimized release builds. This adds the checks for production builds as well.