### PR TITLE
build: npmignore lockfiles, don't gitignore

### DIFF
--- a/templates/.npmignore
+++ b/templates/.npmignore
@@ -1,1 +1,3 @@
 */.cache
+*/yarn.lock
+*/package-lock.json

--- a/templates/angular/near.gitignore
+++ b/templates/angular/near.gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-package-lock.json
 /node_modules
 /.pnp
 .pnp.js

--- a/templates/react/near.gitignore
+++ b/templates/react/near.gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-package-lock.json
 /node_modules
 /.pnp
 .pnp.js

--- a/templates/vanilla/near.gitignore
+++ b/templates/vanilla/near.gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-package-lock.json
 /node_modules
 /.pnp
 .pnp.js

--- a/templates/vue/near.gitignore
+++ b/templates/vue/near.gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-package-lock.json
 /node_modules
 /.pnp
 .pnp.js


### PR DESCRIPTION
We do not want lockfiles to be included in the artifact pushed to npmjs.com, as we do not want to assume ahead of time if a newly-created project is using npm or yarn

Likewise, we do not want to ignore package-lock.json, as a project's creator may prefer to use npm instead of yarn