### PR TITLE
refactor: find styles when rapid-developing Angular

### DIFF
--- a/templates/angular/angular.json
+++ b/templates/angular/angular.json
@@ -21,6 +21,7 @@
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
+            "preserveSymlinks": true,
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "assets": [


### PR DESCRIPTION
If you `cd templates/angular`, `yarn`, then `yarn dev`, the styles didn't load without this, because Angular by default doesn't follow symlinks