### PR TITLE
build: test in diff folder, avoid false positives

### DIFF
--- a/templates/angular/packagejsons/rust/package.json
+++ b/templates/angular/packagejsons/rust/package.json
@@ -55,6 +55,7 @@
     "nodemon": "^2.0.4",
     "protractor": "~7.0.0",
     "puppeteer": "^5.3.0",
+    "shelljs": "^0.8.4",
     "tslint": "~6.1.0",
     "typescript": "~3.9.5"
   }

--- a/templates/vue/packagejsons/rust/package.json
+++ b/templates/vue/packagejsons/rust/package.json
@@ -34,6 +34,7 @@
     "gh-pages": "^3.0.0",
     "near-cli": "^1.0.1",
     "nodemon": "^2.0.4",
+    "shelljs": "^0.8.4",
     "vue-template-compiler": "^2.6.11"
   },
   "eslintConfig": {

--- a/test/test-new-project.js
+++ b/test/test-new-project.js
@@ -1,5 +1,7 @@
 const shell = require('shelljs')
 
+const TEST_PROJECT = '../create-near-app-test-project'
+
 shell.config.fatal = true
 shell.config.verbose = true
 
@@ -30,15 +32,15 @@ const frontends = process.env.FRONTEND
   : ['vanilla', 'react', 'vue', 'angular']
 
 const commands = contracts.map(c => frontends.map(f => (
-  `node index.js tmp-project --contract=${c} --frontend=${f}`
+  `node index.js ${TEST_PROJECT} --contract=${c} --frontend=${f}`
 ))).flat()
 
 commands.forEach(command => {
   // remove temporary blank project
-  shell.rm('-rf', 'tmp-project')
+  shell.rm('-rf', TEST_PROJECT)
   // test generating new project in new dir
   shell.exec(command)
-  shell.cd('tmp-project')
+  shell.cd(TEST_PROJECT)
   shell.env.FILE = 'package.json'
   if (!shell.test('-e', shell.env.FILE)) {
     shell.echo(`Couldn't find ${shell.env.FILE}`)
@@ -47,8 +49,8 @@ commands.forEach(command => {
 
   shell.exec('npm install')
   shell.exec('npm run test')
-  shell.cd('..')
+  shell.cd('-')
 })
 
 // remove temporary blank project
-shell.rm('-rf', 'tmp-project')
+shell.rm('-rf', TEST_PROJECT)


### PR DESCRIPTION
I noticed that sometimes the tests could pass, even though generating a
particular contract+frontend combo failed. This could happen when the
frontend had dependencies covered by the root `package.json`, but not
actually included its own `package.json`

Why did this happen? Because we were creating the test project inside
the root folder, so when the test project tried to look up a given
dependency, it was able to find it in the root project's node_modules
folder.

We need to make sure we test in a realistic environment, where the
project cannot depend on the root folder's node_modules