### PR TITLE
fix: prevent infinite 'yarn dev' loop on node15

### DIFF
--- a/templates/angular/package.json
+++ b/templates/angular/package.json
@@ -13,7 +13,7 @@
     "deploy": "npm run build && npm run deploy:contract && npm run deploy:pages",
     "prestart": "npm run build:contract && npm run dev:deploy:contract",
     "start": "echo The app is starting! It will automatically open in your browser when ready && node set-contract-name.js && ng serve --open",
-    "dev": "nodemon --watch contract --exec \"npm run start\"",
+    "dev": "nodemon --watch contract --ignore \"contract/package*.json\" --exec \"npm run start\"",
     "test": "npm run build:contract:debug && node contract/test && ng test",
     "lint": "ng lint"
   },

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -13,7 +13,7 @@
     "deploy": "npm run build && npm run deploy:contract && npm run deploy:pages",
     "prestart": "npm run build:contract:debug && npm run dev:deploy:contract",
     "start": "echo The app is starting! It will automatically open in your browser when ready && env-cmd -f ./neardev/dev-account.env parcel src/index.html --open",
-    "dev": "nodemon --watch contract --exec \"npm run start\"",
+    "dev": "nodemon --watch contract --ignore \"contract/package*.json\" --exec \"npm run start\"",
     "test": "npm run build:contract:debug && node contract/test && jest test --runInBand"
   },
   "devDependencies": {

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -13,7 +13,7 @@
     "deploy": "npm run build && npm run deploy:contract && npm run deploy:pages",
     "prestart": "npm run build:contract:debug && npm run dev:deploy:contract",
     "start": "echo The app is starting! It will automatically open in your browser when ready && env-cmd -f ./neardev/dev-account.env parcel src/index.html --open",
-    "dev": "nodemon --watch contract --exec \"npm run start\"",
+    "dev": "nodemon --watch contract --ignore \"contract/package*.json\" --exec \"npm run start\"",
     "test": "npm run build:contract:debug && node contract/test && jest test --runInBand"
   },
   "devDependencies": {

--- a/templates/vue/package.json
+++ b/templates/vue/package.json
@@ -13,7 +13,7 @@
     "deploy": "npm run build && npm run deploy:contract && npm run deploy:pages",
     "prestart": "npm run build:contract:debug && npm run dev:deploy:contract",
     "start": "echo The app is starting! It will automatically open in your browser when ready && npm run serve",
-    "dev": "nodemon --watch contract --exec \"npm run start\"",
+    "dev": "nodemon --watch contract --ignore \"contract/package*.json\" --exec \"npm run start\"",
     "test:web": "vue-cli-service test:unit",
     "test": "npm run build:contract:debug && node contract/test && vue-cli-service test:unit",
     "serve": "node copy-dev-account.js && vue-cli-service serve --open",


### PR DESCRIPTION
Node 15 (or is it because of NPM 7?) updates `package.json` and `package-lock.json` every time you run `npm install`. Since the `contract/compile` script runs `npm install`, this means that running `yarn dev` updates these files. And since `yarn dev` also watches these files for changes and re-runs if it spots any, Node 15 causes an infinite loop.

This instructs nodemon to ignore the `package*.json` files.