### PR TITLE
fix(assemblyscript): roll back to v1.0.0

### DIFF
--- a/common/contracts/assemblyscript/package.json
+++ b/common/contracts/assemblyscript/package.json
@@ -9,7 +9,7 @@
     "test": "asp --nologo"
   },
   "dependencies": {
-    "near-sdk-as": "^2.0.0"
+    "near-sdk-as": "1.0.0"
   },
   "devDependencies": {
     "shelljs": "^0.8.4"


### PR DESCRIPTION
Works around https://github.com/near/near-sdk-as/issues/337

create-near-app is currently broken with all 2.x.x versions of near-sdk-as. Using v1.0.0 works, so let's roll back for now.

Also, this uses a specific version, since contracts can be even more sensitive to version changes than frontend apps, and we already started being more careful with our frontend package.json versioning: https://github.com/near/create-near-app/pull/532