### PR TITLE
fix: specify correct contract location in new app

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ const createProject = async function({ contract, frontend, projectDir, veryVerbo
     await replaceInFiles({ files: `${projectDir}/src/**/*`, from: /getGreeting/g, to: 'get_greeting' })
     await replaceInFiles({ files: `${projectDir}/src/**/*`, from: /setGreeting/g, to: 'set_greeting' })
     await replaceInFiles({ files: `${projectDir}/src/**/*`, from: /{ accountId:/g, to: '{ account_id:' })
+    await replaceInFiles({ files: `${projectDir}/src/**/*`, from: /contract\/assembly\/index\.ts/g, to: 'contract/src/lib.rs' })
     await replaceInFiles({ files: `${projectDir}/package.json`, from: 'cd contract && npm run test', to: 'cd contract && cargo test -- --nocapture' })
     await replaceInFiles({ files: `${projectDir}/package.json`, from: 'watch contract -e ts', to: 'watch contract/src -e rs' })
   }

--- a/templates/angular/src/app/app.component.html
+++ b/templates/angular/src/app/app.component.html
@@ -45,12 +45,12 @@
         and <code>setGreeting</code> being called on <code>contract</code>. What's this?
       </li>
       <li>
-        Ultimately, this <code>contract</code> code is defined in <code>assembly/main.ts</code>
+        Ultimately, this <code>contract</code> code is defined in <code>contract/assembly/index.ts</code>
         - this is the source code for your
         <a target="_blank" rel="noreferrer" href="https://docs.near.org/docs/roles/developer/contracts/intro">smart contract</a>.
       </li>
       <li>
-        When you run <code>yarn dev</code>, the code in <code>assembly/main.ts</code>
+        When you run <code>yarn dev</code>, the code in <code>contract/assembly/index.ts</code>
         gets deployed to the NEAR testnet. You can see how this happens by looking in <code>package.json</code>
         at the <code>scripts</code> section to find the <code>dev</code> command.
       </li>

--- a/templates/react/src/App.js
+++ b/templates/react/src/App.js
@@ -160,9 +160,9 @@ export default function App() {
             Look in <code>src/App.js</code> and <code>src/utils.js</code> – you'll see <code>getGreeting</code> and <code>setGreeting</code> being called on <code>contract</code>. What's this?
           </li>
           <li>
-            Ultimately, this <code>contract</code> code is defined in <code>assembly/main.ts</code> – this is the source code for your <a target="_blank" rel="noreferrer" href="https://docs.near.org/docs/roles/developer/contracts/intro">smart contract</a>.</li>
+            Ultimately, this <code>contract</code> code is defined in <code>contract/assembly/index.ts</code> – this is the source code for your <a target="_blank" rel="noreferrer" href="https://docs.near.org/docs/roles/developer/contracts/intro">smart contract</a>.</li>
           <li>
-            When you run <code>yarn dev</code>, the code in <code>assembly/main.ts</code> gets deployed to the NEAR testnet. You can see how this happens by looking in <code>package.json</code> at the <code>scripts</code> section to find the <code>dev</code> command.</li>
+            When you run <code>yarn dev</code>, the code in <code>contract/assembly/index.ts</code> gets deployed to the NEAR testnet. You can see how this happens by looking in <code>package.json</code> at the <code>scripts</code> section to find the <code>dev</code> command.</li>
         </ol>
         <hr />
         <p>

--- a/templates/vanilla/src/index.html
+++ b/templates/vanilla/src/index.html
@@ -73,12 +73,12 @@
         </li>
         <li>
           Ultimately, this <code>contract</code> code is defined in
-          <code>assembly/main.ts</code> – this is the source code for your
+          <code>contract/assembly/index.ts</code> – this is the source code for your
           <a target="_blank" href="https://docs.near.org/docs/roles/developer/contracts/intro">smart contract</a>.
         </li>
         <li>
           When you run <code>yarn dev</code>, the code in
-          <code>assembly/main.ts</code> gets deployed to the NEAR testnet. You
+          <code>contract/assembly/index.ts</code> gets deployed to the NEAR testnet. You
           can see how this happens by looking in <code>package.json</code> at the
           <code>scripts</code> section to find the <code>dev</code> command.
         </li>

--- a/templates/vue/src/components/SignedIn.vue
+++ b/templates/vue/src/components/SignedIn.vue
@@ -36,7 +36,7 @@
         <li>
           Ultimately, this
           <code>contract</code> code is defined in
-          <code>assembly/main.ts</code>
+          <code>contract/assembly/index.ts</code>
           - this is the source code for your
           <a
             target="_blank"
@@ -48,7 +48,7 @@
           When you run
           <code>npm run dev</code> or
           <code>yarn dev</code>, the code in
-          <code>assembly/main.ts</code>
+          <code>contract/assembly/index.ts</code>
           gets deployed to the NEAR testnet. You can see how this happens by looking in
           <code>package.json</code>
           at the


### PR DESCRIPTION
The newly-created app explains where to find the contract code, but was pointing to an outdated location. In addition to fixing it, this also replaces the name of main contract file when using Rust.