### PR TITLE
fix(generated): fix react git ignore

### DIFF
--- a/templates/react/near.gitignore
+++ b/templates/react/near.gitignore
@@ -4,11 +4,13 @@
 /node_modules
 /.pnp
 .pnp.js
+
+# build
 /out
+/dist
 
-#keys
+# keys
 /neardev
-
 
 # testing
 /coverage
@@ -22,6 +24,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+/.cache
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
the `.cache` and `dist` folders aren't being ignored by default.

Also, for Rust contracts the `target` directory wasn't being ignored, but looking at the code it seems to be doing it correctly so it might just not be released? If not, happy to fix that, but it wasn't intuitive for me how to run from source (my JS is rusty sorry)