### PR TITLE
Update references to main files in index.html

### DIFF
--- a/templates/vanilla/src/index.html
+++ b/templates/vanilla/src/index.html
@@ -67,18 +67,18 @@
       </p>
       <ol>
         <li>
-          Look in <code>src/main.js</code> and <code>src/utils.js</code> – you'll see <code>getGreeting</code>
+          Look in <code>src/index.js</code> and <code>src/utils.js</code> – you'll see <code>getGreeting</code>
           and <code>setGreeting</code> being called on <code>contract</code>.
           What's this?
         </li>
         <li>
           Ultimately, this <code>contract</code> code is defined in
-          <code>assembly/main.ts</code> – this is the source code for your
+          <code>assembly/index.ts</code> – this is the source code for your
           <a target="_blank" href="https://docs.near.org/docs/develop/contracts/overview">smart contract</a>.
         </li>
         <li>
           When you run <code>yarn dev</code>, the code in
-          <code>assembly/main.ts</code> gets deployed to the NEAR testnet. You
+          <code>assembly/index.ts</code> gets deployed to the NEAR testnet. You
           can see how this happens by looking in <code>package.json</code> at the
           <code>scripts</code> section to find the <code>dev</code> command.
         </li>


### PR DESCRIPTION
In #389 main.js and main.ts files were renamed to index.js and index.ts .
This can be confusing to newcomers who read the instructions on the index.html .