### PR TITLE
Updated to naj 0.43.1, angular frontend deprecated

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         contract: [assemblyscript, rust]
-        frontend: ['vanilla', 'react', 'vue', 'angular']
+        frontend: ['vanilla', 'react', 'vue']
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2

--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ function copyDir (source, dest, { skip, veryVerbose } = {}) {
 }
 
 const createProject = async function({ contract, frontend, projectDir, veryVerbose }) {
-  if (frontend == "angular") {
-    console.log(chalk`{yellow Angular frontend is deprecated. You can choose vanilla, react or vue.}`);
+  if (frontend === 'angular') {
+    console.log(chalk`{yellow Angular frontend is deprecated. You can choose vanilla, react or vue.}`)
   }
   const templateDir = `/templates/${frontend}`
   const sourceTemplateDir = __dirname + templateDir

--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ function copyDir (source, dest, { skip, veryVerbose } = {}) {
 }
 
 const createProject = async function({ contract, frontend, projectDir, veryVerbose }) {
+  if (frontend == "angular") {
+    console.log(chalk`{yellow Angular frontend is deprecated. You can choose vanilla, react or vue.}`);
+  }
   const templateDir = `/templates/${frontend}`
   const sourceTemplateDir = __dirname + templateDir
   mixpanel.track(frontend, contract)

--- a/templates/angular/package.json
+++ b/templates/angular/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser": "~11.2.11",
     "@angular/platform-browser-dynamic": "~11.2.11",
     "@angular/router": "~11.2.11",
-    "near-api-js": "~0.41.0",
+    "near-api-js": "~0.43.1",
     "rxjs": "~6.6.3",
     "tslib": "~2.2.0",
     "zone.js": "~0.11.4"

--- a/templates/angular/package.json
+++ b/templates/angular/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser": "~11.2.11",
     "@angular/platform-browser-dynamic": "~11.2.11",
     "@angular/router": "~11.2.11",
-    "near-api-js": "~0.43.1",
+    "near-api-js": "~0.41.0",
     "rxjs": "~6.6.3",
     "tslib": "~2.2.0",
     "zone.js": "~0.11.4"

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -32,7 +32,7 @@
     "shelljs": "~0.8.4"
   },
   "dependencies": {
-    "near-api-js": "~0.41.0",
+    "near-api-js": "~0.43.1",
     "react": "~17.0.1",
     "react-dom": "~17.0.1",
     "regenerator-runtime": "~0.13.5"

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -27,7 +27,7 @@
     "shelljs": "~0.8.4"
   },
   "dependencies": {
-    "near-api-js": "~0.41.0",
+    "near-api-js": "~0.43.1",
     "regenerator-runtime": "~0.13.5"
   },
   "jest": {

--- a/templates/vue/package.json
+++ b/templates/vue/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "core-js": "~3.12.1",
-    "near-api-js": "~0.41.0",
+    "near-api-js": "~0.43.1",
     "vue": "~2.6.11"
   },
   "devDependencies": {


### PR DESCRIPTION
We need to release a new version of `create-near-app` since dev-deploy is not working because of outdated `near-cli`. These are additional changes that we want to have in this release:
- `near-api-js` updated to v0.43.1
- deprecation message added for `angular` front-end (it was planned a long time ago, the project is not in use and hard to maintain)