### PR TITLE
fix(near.gitignore): ignore nested node_modules

### DIFF
--- a/near.gitignore
+++ b/near.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 /out

--- a/templates/angular/near.gitignore
+++ b/templates/angular/near.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 /out

--- a/templates/react/near.gitignore
+++ b/templates/react/near.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 

--- a/templates/vanilla/near.gitignore
+++ b/templates/vanilla/near.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 /out

--- a/templates/vue/near.gitignore
+++ b/templates/vue/near.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 # Developer note: near.gitignore will be renamed to .gitignore upon project creation
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 /out


### PR DESCRIPTION
ignore all directories called node_modules. 
Without this change nested `contract/node_modules` will not be ignored as shown below
![image](https://user-images.githubusercontent.com/3725386/155881409-707bf839-4c1d-4143-91b2-5e55eeaaa64e.png)
