### PR TITLE
fix: remove need for specific deps-install command, use install

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,10 +12,10 @@ jobs:
         contract: [ js, rust, assemblyscript ]
         frontend: [ react, vanilla, none ]
         tests: [ js, rust ]
-        exclude:
-        - frontend: vanilla
-        - frontend: none
-        - contract: assemblyscript
+#        exclude:
+#        - frontend: vanilla
+#        - frontend: none
+#        - contract: assemblyscript
 #        include:
 #        - contract: js
 #          frontend: vanilla

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,6 +1,9 @@
 name: Tests E2E
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   e2e:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "npm run build && node index.js",
     "build": "tsc",
-    "test": "npm run build && jest --runInBand",
+    "test": "npm run build && FORCE_COLOR=1 jest --runInBand",
     "test-e2e": "npm run build && ./test/e2e.sh",
     "lint": "eslint .",
     "fix": "eslint . --fix",

--- a/src/make.ts
+++ b/src/make.ts
@@ -102,7 +102,7 @@ export function copyDir(source: string, dest: string, {skip, verbose}: {skip: st
 
 export async function runDepsInstall(projectPath: string) {
   show.depsInstall();
-  const npmCommandArgs = ['run', 'install'];
+  const npmCommandArgs = ['install'];
   await new Promise<void>((resolve, reject) => spawn('npm', npmCommandArgs, {
     cwd: projectPath,
     stdio: 'inherit',

--- a/src/make.ts
+++ b/src/make.ts
@@ -102,7 +102,7 @@ export function copyDir(source: string, dest: string, {skip, verbose}: {skip: st
 
 export async function runDepsInstall(projectPath: string) {
   show.depsInstall();
-  const npmCommandArgs = ['run', 'deps-install'];
+  const npmCommandArgs = ['run', 'install'];
   await new Promise<void>((resolve, reject) => spawn('npm', npmCommandArgs, {
     cwd: projectPath,
     stdio: 'inherit',

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -32,7 +32,7 @@ ${contract === 'rust' ? chalk`🦀 If you are new to Rust please visit {bold {gr
    - {inverse Navigate to your project}:
          {blue cd {bold ${projectName}}}
    ${!install ? chalk`- {inverse Install all dependencies}
-         {blue npm {bold run deps-install}}` : 'Then:'}
+         {blue npm {bold install}}` : 'Then:'}
    - {inverse Test your contract} in NEAR SandBox:
          {blue npm {bold test}}
    - {inverse Deploy your contract} to NEAR TestNet with a temporary dev account:

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -161,7 +161,7 @@ const npmInstallScript = (contract: Contract, hasFrontend: boolean, tests: Testi
         if (tests === 'js') {
           return {'postinstall': 'cd ./integration-tests && npm install && cd ..'};
         } else {
-          return {'postinstall': 'npm install'};
+          return {};
         }
       }
   }

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -125,43 +125,43 @@ const npmInstallScript = (contract: Contract, hasFrontend: boolean, tests: Testi
     case 'assemblyscript':
       if (hasFrontend) {
         if (tests === 'js') {
-          return {'deps-install': 'npm install && cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..'};
+          return {'postinstall': 'cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..'};
         } else {
-          return {'deps-install': 'npm install && cd contract && npm install --ignore-scripts && cd ../frontend && npm install && cd ..'};
+          return {'postinstall': 'cd contract && npm install --ignore-scripts && cd ../frontend && npm install && cd ..'};
         }
       } else {
         if (tests === 'js') {
-          return {'deps-install': 'npm install && cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ..'};
+          return {'postinstall': 'cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ..'};
         } else {
-          return {'deps-install': 'npm install && cd contract && npm install --ignore-scripts && cd ..'};
+          return {'postinstall': 'cd contract && npm install --ignore-scripts && cd ..'};
         }
       }
     case 'js':
       if (hasFrontend) {
         if (tests === 'js') {
-          return {'deps-install': 'npm install && cd contract && npm install && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..'};
+          return {'postinstall': 'cd contract && npm install && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..'};
         } else {
-          return {'deps-install': 'npm install && cd contract && npm install && cd ../frontend && npm install && cd ..'};
+          return {'postinstall': 'cd contract && npm install && cd ../frontend && npm install && cd ..'};
         }
       } else {
         if (tests === 'js') {
-          return {'deps-install': 'npm install && cd contract && npm install && cd ../integration-tests && npm install && cd ..'};
+          return {'postinstall': 'cd contract && npm install && cd ../integration-tests && npm install && cd ..'};
         } else {
-          return {'deps-install': 'npm install && cd contract && npm install && cd ..'};
+          return {'postinstall': 'cd contract && npm install && cd ..'};
         }
       }
     case 'rust':
       if (hasFrontend) {
         if (tests === 'js') {
-          return {'deps-install': 'npm install && cd frontend && npm install && cd ../integration-tests && npm install && cd ..'};
+          return {'postinstall': 'cd frontend && npm install && cd ../integration-tests && npm install && cd ..'};
         } else {
-          return {'deps-install': 'npm install && cd frontend && npm install && cd ..'};
+          return {'postinstall': 'cd frontend && npm install && cd ..'};
         }
       } else {
         if (tests === 'js') {
-          return {'deps-install': 'npm install && cd ./integration-tests && npm install && cd ..'};
+          return {'postinstall': 'cd ./integration-tests && npm install && cd ..'};
         } else {
-          return {'deps-install': 'npm install'};
+          return {'postinstall': 'npm install'};
         }
       }
   }

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -8,7 +8,7 @@ const tracker = mixpanel.init(MIXPANEL_TOKEN);
 
 export const trackingMessage = chalk`NEAR collects anonymous information on the commands used. No personal information that could identify you is shared`;
 
-// TODO: track different failures & deps-install usage
+// TODO: track different failures & install usage
 export const trackUsage = async (frontend: Frontend, contract: Contract) => {
   // prevents logging from CI
   if (process.env.NEAR_ENV === 'ci' || process.env.NODE_ENV === 'ci') {

--- a/templates/shared/README.md
+++ b/templates/shared/README.md
@@ -9,7 +9,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:

--- a/test/__snapshots__/make.test.ts.snap
+++ b/test/__snapshots__/make.test.ts.snap
@@ -65,7 +65,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -415,7 +415,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/build/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -490,7 +490,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -853,7 +853,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install --ignore-scripts && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install --ignore-scripts && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -928,7 +928,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -1940,7 +1940,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/build/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -2015,7 +2015,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -3040,7 +3040,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install --ignore-scripts && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install --ignore-scripts && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -3115,7 +3115,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -4098,7 +4098,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/build/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install --ignore-scripts && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -4173,7 +4173,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -5169,7 +5169,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install --ignore-scripts && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install --ignore-scripts && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -5244,7 +5244,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -5577,7 +5577,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test  -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install && cd ../integration-tests && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install && cd ../integration-tests && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -5652,7 +5652,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -6002,7 +6002,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -6077,7 +6077,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -7072,7 +7072,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test  -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -7147,7 +7147,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -8159,7 +8159,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -8234,7 +8234,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -9200,7 +9200,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test  -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install && cd ../integration-tests && npm install && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -9275,7 +9275,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -10258,7 +10258,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd contract && npm install && cd ../frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd contract && npm install && cd ../frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -10333,7 +10333,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -10687,7 +10687,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test  -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd ./integration-tests && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd ./integration-tests && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -10762,7 +10762,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -11129,7 +11129,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install\\"
+    \\"postinstall\\": \\"npm install\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -11204,7 +11204,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -12220,7 +12220,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test  -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd frontend && npm install && cd ../integration-tests && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd frontend && npm install && cd ../integration-tests && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -12295,7 +12295,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -13324,7 +13324,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -13399,7 +13399,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -14386,7 +14386,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test  -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd frontend && npm install && cd ../integration-tests && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd frontend && npm install && cd ../integration-tests && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"
@@ -14461,7 +14461,7 @@ Quick Start
 
 If you haven't installed dependencies during setup:
 
-    npm run deps-install
+    npm install
 
 
 Build and deploy your contract to TestNet with a temporary dev account:
@@ -15461,7 +15461,7 @@ Array [
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
     \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
-    \\"deps-install\\": \\"npm install && cd frontend && npm install && cd ..\\"
+    \\"postinstall\\": \\"cd frontend && npm install && cd ..\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"

--- a/test/__snapshots__/make.test.ts.snap
+++ b/test/__snapshots__/make.test.ts.snap
@@ -11128,8 +11128,7 @@ Array [
     \\"build:contract\\": \\"cd contract && rustup target add wasm32-unknown-unknown && cargo build --all --target wasm32-unknown-unknown --release\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
-    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
-    \\"postinstall\\": \\"npm install\\"
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\"
   },
   \\"devDependencies\\": {
     \\"near-cli\\": \\"^3.3.0\\"

--- a/test/__snapshots__/user-input.test.ts.snap
+++ b/test/__snapshots__/user-input.test.ts.snap
@@ -28,12 +28,16 @@ https://docs.microsoft.com/en-us/windows/wsl/install
 Exiting now.",
   ],
   Array [
-    "
-Creating a new [1mNEAR dApp[22m",
+    "[43m[30mNotice:[39m[49m AssemblyScript will be deprecated soon and isn't supported on all platforms.
+        [1mConsider writing smart contracts in JavaScript[22m",
   ],
   Array [
     "
-[32mInstalling dependencies in a few folders, this might take a while.[39m
+...creating a new NEAR app...",
+  ],
+  Array [
+    "
+[32mInstalling dependencies in a few folders, this might take a while...[39m
 ",
   ],
   Array [
@@ -62,16 +66,14 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -85,15 +87,13 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -107,16 +107,14 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -130,15 +128,13 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -152,10 +148,8 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -163,7 +157,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -177,9 +171,7 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -187,7 +179,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -201,10 +193,8 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -212,7 +202,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -226,9 +216,7 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -236,7 +224,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -250,10 +238,8 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -261,7 +247,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -275,9 +261,7 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -285,7 +269,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -299,10 +283,8 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -310,7 +292,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -324,9 +306,7 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -334,7 +314,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -348,16 +328,14 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -371,15 +349,13 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -393,16 +369,14 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -416,15 +390,13 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -438,10 +410,8 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -449,7 +419,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -463,9 +433,7 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -473,7 +441,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -487,10 +455,8 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -498,7 +464,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -512,9 +478,7 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -522,7 +486,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -536,10 +500,8 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -547,7 +509,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -561,9 +523,7 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -571,7 +531,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -585,10 +545,8 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -596,7 +554,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -610,9 +568,7 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -620,7 +576,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -635,16 +591,14 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -659,15 +613,13 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -682,16 +634,14 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -706,15 +656,13 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -729,10 +677,8 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -740,7 +686,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -755,9 +701,7 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -765,7 +709,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -780,10 +724,8 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -791,7 +733,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -806,9 +748,7 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -816,7 +756,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -831,10 +771,8 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -842,7 +780,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -857,9 +795,7 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -867,7 +803,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -882,10 +818,8 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   - [7mInstall all dependencies[27m
-         [34mnpm [39m[34m[1mrun deps-install[22m[39m
+   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
+
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -893,7 +827,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -908,9 +842,7 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - [7mNavigate to your project[27m:
-         [34mcd [39m[34m[1mmy_project_name[22m[39m
-   Then:
+   
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -918,7 +850,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
+🧠 See [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;

--- a/test/__snapshots__/user-input.test.ts.snap
+++ b/test/__snapshots__/user-input.test.ts.snap
@@ -28,16 +28,12 @@ https://docs.microsoft.com/en-us/windows/wsl/install
 Exiting now.",
   ],
   Array [
-    "[43m[30mNotice:[39m[49m AssemblyScript will be deprecated soon and isn't supported on all platforms.
-        [1mConsider writing smart contracts in JavaScript[22m",
+    "
+Creating a new [1mNEAR dApp[22m",
   ],
   Array [
     "
-...creating a new NEAR app...",
-  ],
-  Array [
-    "
-[32mInstalling dependencies in a few folders, this might take a while...[39m
+[32mInstalling dependencies in a few folders, this might take a while.[39m
 ",
   ],
   Array [
@@ -66,14 +62,16 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -87,13 +85,15 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -107,14 +107,16 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -128,13 +130,15 @@ Array [
    with a smart contract in [1mAssemblyScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -148,8 +152,10 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -157,7 +163,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -171,7 +177,9 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -179,7 +187,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -193,8 +201,10 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -202,7 +212,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -216,7 +226,9 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -224,7 +236,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -238,8 +250,10 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -247,7 +261,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -261,7 +275,9 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -269,7 +285,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -283,8 +299,10 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -292,7 +310,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -306,7 +324,9 @@ Array [
    with a smart contract in [1mAssemblyScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -314,7 +334,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -328,14 +348,16 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -349,13 +371,15 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -369,14 +393,16 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -390,13 +416,15 @@ Array [
    with a smart contract in [1mJavaScript[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -410,8 +438,10 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -419,7 +449,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -433,7 +463,9 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -441,7 +473,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -455,8 +487,10 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -464,7 +498,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -478,7 +512,9 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template[1m in React.js[22m.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -486,7 +522,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -500,8 +536,10 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -509,7 +547,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -523,7 +561,9 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -531,7 +571,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -545,8 +585,10 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -554,7 +596,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -568,7 +610,9 @@ Array [
    with a smart contract in [1mJavaScript[22m and a frontend template.
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -576,7 +620,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -591,14 +635,16 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -613,13 +659,15 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -634,14 +682,16 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -656,13 +706,15 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
          [34mnpm [39m[34m[1mrun deploy[22m[39m
    
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -677,8 +729,10 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -686,7 +740,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -701,7 +755,9 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -709,7 +765,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -724,8 +780,10 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -733,7 +791,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -748,7 +806,9 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -756,7 +816,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -771,8 +831,10 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -780,7 +842,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -795,7 +857,9 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -803,7 +867,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -818,8 +882,10 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   - Run [34mnpm [39m[34m[1minstall[22m[39m to install dependencies in all directories
-
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   - [7mInstall all dependencies[27m
+         [34mnpm [39m[34m[1minstall[22m[39m
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -827,7 +893,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;
@@ -842,7 +908,9 @@ Array [
 🦀 If you are new to Rust please visit [1m[32mhttps://www.rust-lang.org [39m[22m
 
   [1m[43m[30mYour next steps[39m[49m[22m:
-   
+   - [7mNavigate to your project[27m:
+         [34mcd [39m[34m[1mmy_project_name[22m[39m
+   Then:
    - [7mTest your contract[27m in NEAR SandBox:
          [34mnpm [39m[34m[1mtest[22m[39m
    - [7mDeploy your contract[27m to NEAR TestNet with a temporary dev account:
@@ -850,7 +918,7 @@ Array [
    - [7mStart your frontend[27m:
          [34mnpm [39m[34m[1mstart[22m[39m
 
-🧠 See [1m[92mREADME.md[39m[22m to explore further.",
+🧠 Read [1m[92mREADME.md[39m[22m to explore further.",
   ],
 ]
 `;


### PR DESCRIPTION
unclear to me why this isn't hooked into install. This was a footgun I ran into, devs shouldn't have to know about this command.

Tests were already broken, didn't extensively test this