### PR TITLE
fix: remove rlib from Rust template crate type

### DIFF
--- a/templates/contracts/rust/Cargo.toml
+++ b/templates/contracts/rust/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Near Inc <hello@near.org>"]
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = "4.0.0"

--- a/test/__snapshots__/make.test.ts.snap
+++ b/test/__snapshots__/make.test.ts.snap
@@ -10453,7 +10453,7 @@ authors = [\\"Near Inc <hello@near.org>\\"]
 edition = \\"2021\\"
 
 [lib]
-crate-type = [\\"cdylib\\", \\"rlib\\"]
+crate-type = [\\"cdylib\\"]
 
 [dependencies]
 near-sdk = \\"4.0.0\\"
@@ -10882,7 +10882,7 @@ authors = [\\"Near Inc <hello@near.org>\\"]
 edition = \\"2021\\"
 
 [lib]
-crate-type = [\\"cdylib\\", \\"rlib\\"]
+crate-type = [\\"cdylib\\"]
 
 [dependencies]
 near-sdk = \\"4.0.0\\"
@@ -11324,7 +11324,7 @@ authors = [\\"Near Inc <hello@near.org>\\"]
 edition = \\"2021\\"
 
 [lib]
-crate-type = [\\"cdylib\\", \\"rlib\\"]
+crate-type = [\\"cdylib\\"]
 
 [dependencies]
 near-sdk = \\"4.0.0\\"
@@ -12415,7 +12415,7 @@ authors = [\\"Near Inc <hello@near.org>\\"]
 edition = \\"2021\\"
 
 [lib]
-crate-type = [\\"cdylib\\", \\"rlib\\"]
+crate-type = [\\"cdylib\\"]
 
 [dependencies]
 near-sdk = \\"4.0.0\\"
@@ -13519,7 +13519,7 @@ authors = [\\"Near Inc <hello@near.org>\\"]
 edition = \\"2021\\"
 
 [lib]
-crate-type = [\\"cdylib\\", \\"rlib\\"]
+crate-type = [\\"cdylib\\"]
 
 [dependencies]
 near-sdk = \\"4.0.0\\"
@@ -14581,7 +14581,7 @@ authors = [\\"Near Inc <hello@near.org>\\"]
 edition = \\"2021\\"
 
 [lib]
-crate-type = [\\"cdylib\\", \\"rlib\\"]
+crate-type = [\\"cdylib\\"]
 
 [dependencies]
 near-sdk = \\"4.0.0\\"


### PR DESCRIPTION
It's inefficient, should not be defaulting to this as it has no benefit and just disables LTO