### PR TITLE
fix: readme - warn about global installation

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [ opened, reopened ]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     strategy:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   e2e:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ To create a new NEAR project run this and follow interactive prompts:
 
     npx create-near-app
 
+> If you've previously installed `create-near-app` globally via `npm install -g create-near-app`, please uninstall the package using `npm uninstall -g create-near-app` to ensure that `npx` always uses the latest version.
+
 Follow the instructions in the README.md in the project you just created! 🚀
 
 You can create contracts written in:


### PR DESCRIPTION
Added a similar warning to create-react-app: https://create-react-app.dev/docs/getting-started/