### PR TITLE
Fix NearBindgen Description Comment Line

### DIFF
--- a/templates/contracts/js/src/contract.ts
+++ b/templates/contracts/js/src/contract.ts
@@ -1,6 +1,6 @@
 import { NearBindgen, NearContract, near, call, view } from 'near-sdk-js';
 
-// The @NearBindgen decorator allows this code to compile to Base64.
+// @NearBindgen adds helper functions to the class which Babel uses to generate the contract interface
 @NearBindgen
 class MyContract extends NearContract {
   greeting: string;

--- a/test/__snapshots__/make.test.ts.snap
+++ b/test/__snapshots__/make.test.ts.snap
@@ -5613,7 +5613,7 @@ Array [
   "--js_none_js--contract--src--contract.ts",
   "import { NearBindgen, NearContract, near, call, view } from 'near-sdk-js';
 
-// The @NearBindgen decorator allows this code to compile to Base64.
+// @NearBindgen adds helper functions to the class which Babel uses to generate the contract interface
 @NearBindgen
 class MyContract extends NearContract {
   greeting: string;
@@ -6058,7 +6058,7 @@ Array [
   "--js_none_rust--contract--src--contract.ts",
   "import { NearBindgen, NearContract, near, call, view } from 'near-sdk-js';
 
-// The @NearBindgen decorator allows this code to compile to Base64.
+// @NearBindgen adds helper functions to the class which Babel uses to generate the contract interface
 @NearBindgen
 class MyContract extends NearContract {
   greeting: string;
@@ -6520,7 +6520,7 @@ Array [
   "--js_react_js--contract--src--contract.ts",
   "import { NearBindgen, NearContract, near, call, view } from 'near-sdk-js';
 
-// The @NearBindgen decorator allows this code to compile to Base64.
+// @NearBindgen adds helper functions to the class which Babel uses to generate the contract interface
 @NearBindgen
 class MyContract extends NearContract {
   greeting: string;
@@ -7666,7 +7666,7 @@ Array [
   "--js_react_rust--contract--src--contract.ts",
   "import { NearBindgen, NearContract, near, call, view } from 'near-sdk-js';
 
-// The @NearBindgen decorator allows this code to compile to Base64.
+// @NearBindgen adds helper functions to the class which Babel uses to generate the contract interface
 @NearBindgen
 class MyContract extends NearContract {
   greeting: string;
@@ -8829,7 +8829,7 @@ Array [
   "--js_vanilla_js--contract--src--contract.ts",
   "import { NearBindgen, NearContract, near, call, view } from 'near-sdk-js';
 
-// The @NearBindgen decorator allows this code to compile to Base64.
+// @NearBindgen adds helper functions to the class which Babel uses to generate the contract interface
 @NearBindgen
 class MyContract extends NearContract {
   greeting: string;
@@ -9946,7 +9946,7 @@ Array [
   "--js_vanilla_rust--contract--src--contract.ts",
   "import { NearBindgen, NearContract, near, call, view } from 'near-sdk-js';
 
-// The @NearBindgen decorator allows this code to compile to Base64.
+// @NearBindgen adds helper functions to the class which Babel uses to generate the contract interface
 @NearBindgen
 class MyContract extends NearContract {
   greeting: string;


### PR DESCRIPTION
Serhii pointed out earlier today the following: 

> @NearBindgen decorator just adds a bunch of helper functions to the class. Babel then use it to generate the contract interface. You can check it in the end of each JS file (check your /build folder).

This PR makes this fix in the template for the JS contract.