### PR TITLE
always kill sandbox process

### DIFF
--- a/templates/integration-tests/js-tests/src/main.ava.ts
+++ b/templates/integration-tests/js-tests/src/main.ava.ts
@@ -23,7 +23,7 @@ test.beforeEach(async (t) => {
   t.context.accounts = { root, contract };
 });
 
-test.afterEach(async (t) => {
+test.afterEach.always(async (t) => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch((error) => {
     console.log('Failed to stop the Sandbox:', error);

--- a/test/__snapshots__/make.test.ts.snap
+++ b/test/__snapshots__/make.test.ts.snap
@@ -431,7 +431,7 @@ test.beforeEach(async (t) => {
   t.context.accounts = { root, contract };
 });
 
-test.afterEach(async (t) => {
+test.afterEach.always(async (t) => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch((error) => {
     console.log('Failed to stop the Sandbox:', error);
@@ -2116,7 +2116,7 @@ test.beforeEach(async (t) => {
   t.context.accounts = { root, contract };
 });
 
-test.afterEach(async (t) => {
+test.afterEach.always(async (t) => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch((error) => {
     console.log('Failed to stop the Sandbox:', error);
@@ -4477,7 +4477,7 @@ test.beforeEach(async (t) => {
   t.context.accounts = { root, contract };
 });
 
-test.afterEach(async (t) => {
+test.afterEach.always(async (t) => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch((error) => {
     console.log('Failed to stop the Sandbox:', error);
@@ -6171,7 +6171,7 @@ test.beforeEach(async (t) => {
   t.context.accounts = { root, contract };
 });
 
-test.afterEach(async (t) => {
+test.afterEach.always(async (t) => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch((error) => {
     console.log('Failed to stop the Sandbox:', error);
@@ -7958,7 +7958,7 @@ test.beforeEach(async (t) => {
   t.context.accounts = { root, contract };
 });
 
-test.afterEach(async (t) => {
+test.afterEach.always(async (t) => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch((error) => {
     console.log('Failed to stop the Sandbox:', error);
@@ -10421,7 +10421,7 @@ test.beforeEach(async (t) => {
   t.context.accounts = { root, contract };
 });
 
-test.afterEach(async (t) => {
+test.afterEach.always(async (t) => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch((error) => {
     console.log('Failed to stop the Sandbox:', error);


### PR DESCRIPTION
Before this change, we were not stopping near-sandbox processes in case the test failed. With time it leads to high memory, CPU, and battery usage.
afterEach.always(...) solves the problem.