### PR TITLE
fix: rust template deploy instruction is broken

### DIFF
--- a/templates/contracts/rust/README.md
+++ b/templates/contracts/rust/README.md
@@ -78,7 +78,7 @@ near view <dev-account> get_greeting
 
 ```bash
 # Use near-cli to set a new greeting
-near call <dev-account> set_greeting '{"greeting":"howdy"}' --accountId <dev-account>
+near call <dev-account> set_greeting '{"message":"howdy"}' --accountId <dev-account>
 ```
 
 **Tip:** If you would like to call `set_greeting` using your own account, first login into NEAR using:


### PR DESCRIPTION
Rust template contract field name is [`message`](https://github.com/luuuu-learning/create-near-app/blob/master/templates/contracts/rust/src/lib.rs#L19), but in readme the [`set_greeting`](https://github.com/luuuu-learning/create-near-app/blob/master/templates/contracts/rust/README.md?plain=1#L81) instruction is using `greeting` as field name, which will get missing field error if we call it.
```
ServerTransactionError: {"index":0,"kind":{"ExecutionError":"Smart contract panicked: panicked at 'Failed to deserialize input from JSON.: Error(\"missing field `message`\", line: 1, column: 20)', src/lib.rs:30:1"}}
```