### PR TITLE
link in /rust/src/lib.rs was deprecated. updated to latest link

### DIFF
--- a/templates/contracts/rust/src/lib.rs
+++ b/templates/contracts/rust/src/lib.rs
@@ -2,7 +2,7 @@
  * Example smart contract written in RUST
  *
  * Learn more about writing NEAR smart contracts with Rust:
- * https://near-docs.io/develop/Contract
+ * https://near-docs.io/develop/welcome
  *
  */
 


### PR DESCRIPTION
Updated link as the last link led to a 404 error. Hopefully this well help future developers!