### PR TITLE
fix: near-sdk-js version

### DIFF
--- a/templates/contracts/js/babel.config.json
+++ b/templates/contracts/js/babel.config.json
@@ -1,7 +1,4 @@
 {
-  "plugins": [
-    "near-sdk-js/lib/build-tools/near-bindgen-exporter",
-    ["@babel/plugin-proposal-decorators", {"version": "legacy"}]
-  ],
+  "plugins": [["@babel/plugin-proposal-decorators", { "version": "legacy" }]],
   "presets": ["@babel/preset-typescript"]
 }

--- a/templates/contracts/js/package-lock.json
+++ b/templates/contracts/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "(MIT AND Apache-2.0)",
       "dependencies": {
         "near-cli": "^3.4.0",
-        "near-sdk-js": "0.4.0"
+        "near-sdk-js": "1.0.0"
       },
       "devDependencies": {
         "typescript": "^4.7.4"

--- a/templates/contracts/js/package.json
+++ b/templates/contracts/js/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "near-cli": "^3.4.0",
-    "near-sdk-js": "0.6.0"
+    "near-sdk-js": "1.0.0"
   },
   "devDependencies": {
     "typescript": "^4.7.4",


### PR DESCRIPTION
### 🚧 Issue
An error occurred when doing `npm run build` to **contract (js-template)**
and found that the version of `near-sdk-js` is diffrent from [near-example](https://github.com/near-examples/hello-near-js/pull/14/files).
#### npm run build error
```
> hello_near@1.0.0 build
> ./build.sh

>> Building contract
[build] › …  awaiting  Creating build directory...
…  awaiting  Validatig src/contract.ts contract...
[exec] › ✖  error     Error: Command failed: node_modules/near-sdk-js/lib/cli/deps/binaryen/wasi-stub/run.sh build/hello_near.wasm >/dev/null 
node_modules/near-sdk-js/lib/cli/deps/binaryen/wasi-stub/run.sh: line 13: /Users/yunsu/Project: No such file or directory

    at ChildProcess.exithandler (node:child_process:398:12)
    at ChildProcess.emit (node:events:527:28)
    at maybeClose (node:internal/child_process:1092:16)
    at Socket.<anonymous> (node:internal/child_process:451:11)
    at Socket.emit (node:events:527:28)
    at Pipe.<anonymous> (node:net:709:12)
```


### Additional modified code
When only a was changed, an error occurred due to babel plugin (`near-sdk-js/lib/build-tools/near-bindgen-exporter`), so I deleted it and it was deployed without any problems. 
_Please check if there are side effects when you delete this babel plugin._

#### npm run build - babel plugin error
```
> hello_near@1.0.0 build
> ./build.sh

>> Building contract
[createJsFileWithRollup] › …  awaiting  Creating src/contract.ts file with Rollup...
/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:233
  Error.captureStackTrace(error);
        ^

Error: Cannot find module '/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/near-sdk-js/lib/build-tools/near-bindgen-exporter' imported from /Users/yunsu/Project Web/create-near-app/templates/contracts/js/babel-virtual-resolve-base.js
    at new NodeError (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:203:5)
    at finalizeResolution (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:547:11)
    at moduleResolve (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:909:10)
    at defaultResolve (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:984:15)
    at resolve (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:998:12)
    at resolve (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/config/files/import-meta-resolve.js:13:10)
    at tryImportMetaResolve (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/config/files/plugins.js:123:45)
    at resolveStandardizedNameForImport (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/config/files/plugins.js:145:19)
    at resolveStandardizedName (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/config/files/plugins.js:154:12)
    at loadPlugin (/Users/yunsu/Project Web/create-near-app/templates/contracts/js/node_modules/@babel/core/lib/config/files/plugins.js:47:20) {
  code: 'PLUGIN_ERROR',
  pluginCode: 'ERR_MODULE_NOT_FOUND',
  plugin: 'babel',
  hook: 'transform',
  id: '/Users/yunsu/Project Web/create-near-app/templates/contracts/js/src/contract.ts',
  watchFiles: [
    '/Users/yunsu/Project Web/create-near-app/templates/contracts/js/src/contract.ts'
  ]
}
```
