### PR TITLE
fix: force Rust 1.69 with rust-toolchain.toml

### DIFF
--- a/templates/shared/rust-toolchain.toml
+++ b/templates/shared/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.69"


### PR DESCRIPTION
As contracts compiled with Rust 1.70 are not working currently this commit ensures that users who use rustup aren't experiencing errors. Resolves #2009

Note that the e2e tests are failing for me locally both with and without this commit. I'd likely to see if they succeed in the CI before investigating further.