### PR TITLE
Build contract before integration tests

### DIFF
--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -44,15 +44,17 @@ const buildScript = (hasFrontend: boolean): Entries => hasFrontend ? {
   'build': 'npm run build:contract',
 };
 
+const buildContractScriptName = 'build:contract';
+
 const buildContractScript = (contract: Contract): Entries => {
   switch (contract) {
     case 'js':
       return {
-        'build:contract': 'cd contract && npm run build',
+        [buildContractScriptName]: 'cd contract && npm run build',
       };
     case 'rust':
       return {
-        'build:contract': 'cd contract && ./build.sh',
+        [buildContractScriptName]: 'cd contract && ./build.sh',
       };
   }
 };
@@ -93,7 +95,7 @@ const integrationTestScripts = (contract: Contract, tests: TestingFramework): En
   }
 
   return {
-    'test:integration': `cd integration-tests && ${run_test}`,
+    'test:integration': `npm run ${buildContractScriptName} && cd integration-tests && ${run_test}`,
   };
 };
 

--- a/test/__snapshots__/make.test.ts.snap
+++ b/test/__snapshots__/make.test.ts.snap
@@ -466,7 +466,7 @@ Array [
     \\"build:contract\\": \\"cd contract && npm run build\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
-    \\"test:integration\\": \\"cd integration-tests && npm test -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"echo no frontend && cd integration-tests && npm install && cd .. && cd contract && npm install\\"
   },
   \\"devDependencies\\": {
@@ -474,6 +474,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'js' 'none' 'js': --js_none_js--rust-toolchain.toml 1`] = `
+Array [
+  "--js_none_js--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -954,7 +963,7 @@ Array [
     \\"build:contract\\": \\"cd contract && npm run build\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
-    \\"test:integration\\": \\"cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"echo no frontend && echo rs tests && cd contract && npm install\\"
   },
   \\"devDependencies\\": {
@@ -962,6 +971,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'js' 'none' 'rust': --js_none_rust--rust-toolchain.toml 1`] = `
+Array [
+  "--js_none_rust--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -2140,7 +2158,7 @@ Array [
     \\"build:contract\\": \\"cd contract && npm run build\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
-    \\"test:integration\\": \\"cd integration-tests && npm test -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && cd integration-tests && npm install && cd .. && cd contract && npm install\\"
   },
   \\"devDependencies\\": {
@@ -2148,6 +2166,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'js' 'react' 'js': --js_react_js--rust-toolchain.toml 1`] = `
+Array [
+  "--js_react_js--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -3337,7 +3364,7 @@ Array [
     \\"build:contract\\": \\"cd contract && npm run build\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
-    \\"test:integration\\": \\"cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && echo rs tests && cd contract && npm install\\"
   },
   \\"devDependencies\\": {
@@ -3345,6 +3372,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'js' 'react' 'rust': --js_react_rust--rust-toolchain.toml 1`] = `
+Array [
+  "--js_react_rust--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -4478,7 +4514,7 @@ Array [
     \\"build:contract\\": \\"cd contract && npm run build\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
-    \\"test:integration\\": \\"cd integration-tests && npm test -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/build/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && cd integration-tests && npm install && cd .. && cd contract && npm install\\"
   },
   \\"devDependencies\\": {
@@ -4486,6 +4522,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'js' 'vanilla' 'js': --js_vanilla_js--rust-toolchain.toml 1`] = `
+Array [
+  "--js_vanilla_js--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -5630,7 +5675,7 @@ Array [
     \\"build:contract\\": \\"cd contract && npm run build\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && npm test\\",
-    \\"test:integration\\": \\"cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/build/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && echo rs tests && cd contract && npm install\\"
   },
   \\"devDependencies\\": {
@@ -5638,6 +5683,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'js' 'vanilla' 'rust': --js_vanilla_rust--rust-toolchain.toml 1`] = `
+Array [
+  "--js_vanilla_rust--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -6150,7 +6204,7 @@ Array [
     \\"build:contract\\": \\"cd contract && ./build.sh\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
-    \\"test:integration\\": \\"cd integration-tests && npm test -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"echo no frontend && cd integration-tests && npm install && cd .. && echo rs contract\\"
   },
   \\"devDependencies\\": {
@@ -6158,6 +6212,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'rust' 'none' 'js': --rust_none_js--rust-toolchain.toml 1`] = `
+Array [
+  "--rust_none_js--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -6681,7 +6744,7 @@ Array [
     \\"build:contract\\": \\"cd contract && ./build.sh\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
-    \\"test:integration\\": \\"cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"echo no frontend && echo rs tests && echo rs contract\\"
   },
   \\"devDependencies\\": {
@@ -6689,6 +6752,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'rust' 'none' 'rust': --rust_none_rust--rust-toolchain.toml 1`] = `
+Array [
+  "--rust_none_rust--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -7910,7 +7982,7 @@ Array [
     \\"build:contract\\": \\"cd contract && ./build.sh\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
-    \\"test:integration\\": \\"cd integration-tests && npm test -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && cd integration-tests && npm install && cd .. && echo rs contract\\"
   },
   \\"devDependencies\\": {
@@ -7918,6 +7990,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'rust' 'react' 'js': --rust_react_js--rust-toolchain.toml 1`] = `
+Array [
+  "--rust_react_js--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -9150,7 +9231,7 @@ Array [
     \\"build:contract\\": \\"cd contract && ./build.sh\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
-    \\"test:integration\\": \\"cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && echo rs tests && echo rs contract\\"
   },
   \\"devDependencies\\": {
@@ -9158,6 +9239,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'rust' 'react' 'rust': --rust_react_rust--rust-toolchain.toml 1`] = `
+Array [
+  "--rust_react_rust--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -10334,7 +10424,7 @@ Array [
     \\"build:contract\\": \\"cd contract && ./build.sh\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
-    \\"test:integration\\": \\"cd integration-tests && npm test -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && npm test -- -- \\\\\\"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && cd integration-tests && npm install && cd .. && echo rs contract\\"
   },
   \\"devDependencies\\": {
@@ -10342,6 +10432,15 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'rust' 'vanilla' 'js': --rust_vanilla_js--rust-toolchain.toml 1`] = `
+Array [
+  "--rust_vanilla_js--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;
 
@@ -11529,7 +11628,7 @@ Array [
     \\"build:contract\\": \\"cd contract && ./build.sh\\",
     \\"test\\": \\"npm run test:unit && npm run test:integration\\",
     \\"test:unit\\": \\"cd contract && cargo test\\",
-    \\"test:integration\\": \\"cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
+    \\"test:integration\\": \\"npm run build:contract && cd integration-tests && cargo run --example integration-tests \\\\\\"../contract/target/wasm32-unknown-unknown/release/hello_near.wasm\\\\\\"\\",
     \\"postinstall\\": \\"cd frontend && npm install && cd .. && echo rs tests && echo rs contract\\"
   },
   \\"devDependencies\\": {
@@ -11537,5 +11636,14 @@ Array [
   },
   \\"dependencies\\": {}
 }",
+]
+`;
+
+exports[`create 'rust' 'vanilla' 'rust': --rust_vanilla_rust--rust-toolchain.toml 1`] = `
+Array [
+  "--rust_vanilla_rust--rust-toolchain.toml",
+  "[toolchain]
+channel = \\"1.69\\"
+",
 ]
 `;


### PR DESCRIPTION
The integration tests depend on a built artifact, so they'll fail unless the `build:contract` command is ran manually before running integration tests.

It's also error-prone as users might not realize that they have to rebuild manually before running integration tests, and they might get confused.

Incidentally this change also fixes the e2e tests that were failing in master locally on a fresh checkout of the repository.

Branched out from https://github.com/near/create-near-app/pull/2013, otherwise tests are failing.