### PR TITLE
refactor: make deploy.sh reusable

### DIFF
--- a/templates/contracts/rust/deploy.sh
+++ b/templates/contracts/rust/deploy.sh
@@ -10,4 +10,4 @@ fi
 echo ">> Deploying contract"
 
 # https://docs.near.org/tools/near-cli#near-dev-deploy
-near dev-deploy --wasmFile ./target/wasm32-unknown-unknown/release/hello_near.wasm
+near dev-deploy --wasmFile ./target/wasm32-unknown-unknown/release/*.wasm


### PR DESCRIPTION
When building the rust smart contract the the wasm file is named after the project. The deploy script however makes it static by expecting hello_near.wasm to be present in the release folder so any project thats not named "hello_near" has to modify it manually which might not always be clear to the end user of the cli tool.

This issue does not persist when choosing typescript as a contract language since the build script hard codes the name of the wasm file.