### PR TITLE
refactor: change the npm test script to build the ts contract

### DIFF
--- a/templates/contracts/ts/package.json
+++ b/templates/contracts/ts/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "near-sdk-js build src/contract.ts build/hello_near.wasm",
     "deploy": "near dev-deploy --wasmFile build/hello_near.wasm",
-    "test": "npm run build && cd sandbox-ts && $npm_execpath run test -- -- ../build/hello_near.wasm",
+    "test": "$npm_execpath run build && cd sandbox-ts && $npm_execpath run test -- -- ../build/hello_near.wasm",
     "postinstall": "cd sandbox-ts && $npm_execpath i"
   },
   "dependencies": {

--- a/templates/contracts/ts/package.json
+++ b/templates/contracts/ts/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "near-sdk-js build src/contract.ts build/hello_near.wasm",
     "deploy": "near dev-deploy --wasmFile build/hello_near.wasm",
-    "test": "cd sandbox-ts && $npm_execpath run test -- -- ../build/hello_near.wasm",
+    "test": "npm run build && cd sandbox-ts && $npm_execpath run test -- -- ../build/hello_near.wasm",
     "postinstall": "cd sandbox-ts && $npm_execpath i"
   },
   "dependencies": {


### PR DESCRIPTION
The `test` script in package.json currently requires the user to manually build the contract in prior to running the tests.

Ideally the flow would be the same as the `test.sh` script for the rust smart contract where the test script builds the contract prior execution.