### PR TITLE
fix: use install instead of i

### DIFF
--- a/templates/contracts/ts/package.json
+++ b/templates/contracts/ts/package.json
@@ -10,7 +10,7 @@
     "build": "near-sdk-js build src/contract.ts build/hello_near.wasm",
     "deploy": "near dev-deploy --wasmFile build/hello_near.wasm",
     "test": "$npm_execpath run build && cd sandbox-ts && $npm_execpath run test -- -- ../build/hello_near.wasm",
-    "postinstall": "cd sandbox-ts && $npm_execpath i"
+    "postinstall": "cd sandbox-ts && $npm_execpath install"
   },
   "dependencies": {
     "near-cli": "^3.4.2",


### PR DESCRIPTION
yarn does not have `i` so it is better to use the generic `"install"` 