### PR TITLE
fix(contracts/ts): remove erroneous `--` in test script

### DIFF
--- a/templates/contracts/ts/package.json
+++ b/templates/contracts/ts/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "near-sdk-js build src/contract.ts build/hello_near.wasm",
     "deploy": "near dev-deploy --wasmFile build/hello_near.wasm",
-    "test": "$npm_execpath run build && cd sandbox-ts && $npm_execpath run test -- -- ../build/hello_near.wasm",
+    "test": "$npm_execpath run build && cd sandbox-ts && $npm_execpath run test -- ../build/hello_near.wasm",
     "postinstall": "cd sandbox-ts && $npm_execpath install"
   },
   "dependencies": {


### PR DESCRIPTION
Before on `pnpm run test` for the contract template with TS:

```
  Error {
    message: 'Could not find \'--\' relative to any package.json file or your current working directory (/home/matt/Documents/hello-near-ts/sandbox-ts)',
  }
```

Now it works fine.