### PR TITLE
feat: fixed class vs className incorrect use

### DIFF
--- a/templates/frontend/next-app/src/app/hello-components/page.js
+++ b/templates/frontend/next-app/src/app/hello-components/page.js
@@ -1,15 +1,16 @@
-import dynamic from 'next/dynamic';
+import dynamic from "next/dynamic";
 
-import styles from '@/app/app.module.css';
-import { DocsCard, HelloNearCard } from '@/components/cards';
-import { NetworkId, ComponentMap } from '@/config';
+import styles from "@/app/app.module.css";
+import { DocsCard, HelloNearCard } from "@/components/cards";
+import { NetworkId, ComponentMap } from "@/config";
 
-const Component = dynamic(() => import('@/components/vm-component'), { ssr: false });
+const Component = dynamic(() => import("@/components/vm-component"), {
+  ssr: false,
+});
 
 const socialComponents = ComponentMap[NetworkId];
 
 export default function HelloComponents() {
-
   return (
     <>
       <main className={styles.main}>
@@ -20,15 +21,18 @@ export default function HelloComponents() {
           </p>
         </div>
         <div className={styles.center}>
-          <h1> <code>Multi-chain</code> Components Made Simple </h1>
+          <h1>
+            {" "}
+            <code>Multi-chain</code> Components Made Simple{" "}
+          </h1>
         </div>
-        <div className='row'>
-          <div class="col-6">
+        <div className="row">
+          <div className="col-6">
             <Component src={socialComponents.HelloNear} />
-            <p class="my-4">&nbsp;</p>
+            <p className="my-4">&nbsp;</p>
             <Component src={socialComponents.LoveNear} />
           </div>
-          <div class="col-6">
+          <div className="col-6">
             <Component src={socialComponents.Lido} />
           </div>
         </div>

--- a/templates/frontend/next-page/src/components/navigation.js
+++ b/templates/frontend/next-page/src/components/navigation.js
@@ -1,15 +1,14 @@
-import Image from 'next/image';
-import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 
-import NearLogo from 'public/near-logo.svg';
-import { useWallet } from '@/wallets/wallet-selector';
+import NearLogo from "public/near-logo.svg";
+import { useWallet } from "@/wallets/wallet-selector";
 
 export const Navigation = () => {
-
   const { signedAccountId, logOut, logIn } = useWallet();
-  const [action, setAction] = useState(() => { });
-  const [label, setLabel] = useState('Loading...');
+  const [action, setAction] = useState(() => {});
+  const [label, setLabel] = useState("Loading...");
 
   useEffect(() => {
     if (signedAccountId) {
@@ -17,7 +16,7 @@ export const Navigation = () => {
       setLabel(`Logout ${signedAccountId}`);
     } else {
       setAction(() => logIn);
-      setLabel('Login');
+      setLabel("Login");
     }
   }, [signedAccountId, logOut, logIn, setAction, setLabel]);
 
@@ -25,10 +24,19 @@ export const Navigation = () => {
     <nav className="navbar navbar-expand-lg">
       <div className="container-fluid">
         <Link href="/" passHref legacyBehavior>
-          <Image priority src={NearLogo} alt="NEAR" width="30" height="24" className="d-inline-block align-text-top" />
+          <Image
+            priority
+            src={NearLogo}
+            alt="NEAR"
+            width="30"
+            height="24"
+            className="d-inline-block align-text-top"
+          />
         </Link>
-        <div className='navbar-nav pt-1'>
-          <button className="btn btn-secondary" onClick={action} > {label} </button>
+        <div className="navbar-nav pt-1">
+          <button className="btn btn-secondary" onClick={action}>
+            {label}
+          </button>
         </div>
       </div>
     </nav>

--- a/templates/frontend/next-page/src/components/vm-component.js
+++ b/templates/frontend/next-page/src/components/vm-component.js
@@ -1,10 +1,10 @@
-'use client';
-import { useEffect } from 'react';
-import { useInitNear, Widget, EthersProviderContext } from 'near-social-vm';
+"use client";
+import { useEffect } from "react";
+import { useInitNear, Widget, EthersProviderContext } from "near-social-vm";
 
-import { useWallet } from '@/wallets/wallet-selector';
-import { useEthersProviderContext } from '@/wallets/web3-wallet';
-import { NetworkId } from '@/config';
+import { useWallet } from "@/wallets/wallet-selector";
+import { useEthersProviderContext } from "@/wallets/web3-wallet";
+import { NetworkId } from "@/config";
 
 export default function Component({ src }) {
   const ethersContext = useEthersProviderContext();
@@ -20,7 +20,12 @@ export default function Component({ src }) {
       <EthersProviderContext.Provider value={ethersContext}>
         <Widget src={src} />
       </EthersProviderContext.Provider>
-      <p className="mt-4 small"> <span className="text-secondary">Source:</span> <a href={`https://near.social/mob.near/widget/WidgetSource?src=${src}`}> {src} </a> </p>
+      <p className="mt-4 small">
+        <span className="text-secondary">Source:</span>
+        <a href={`https://near.social/mob.near/widget/WidgetSource?src=${src}`}>
+          {src}
+        </a>
+      </p>
     </div>
   );
 }

--- a/templates/frontend/next-page/src/pages/hello-components/index.js
+++ b/templates/frontend/next-page/src/pages/hello-components/index.js
@@ -27,12 +27,12 @@ export default function HelloComponents() {
           </h1>
         </div>
         <div className="row">
-          <div class="col-6">
+          <div className="col-6">
             <Component src={socialComponents.HelloNear} />
-            <p class="my-4">&nbsp;</p>
+            <p className="my-4">&nbsp;</p>
             <Component src={socialComponents.LoveNear} />
           </div>
-          <div class="col-6">
+          <div className="col-6">
             <Component src={socialComponents.Lido} />
           </div>
         </div>

--- a/templates/frontend/vanilla/src/components.js
+++ b/templates/frontend/vanilla/src/components.js
@@ -1,59 +1,72 @@
-import { createRoot } from 'react-dom/client';
-import { Wallet } from './near-wallet';
-import { useInitNear, Widget } from 'near-social-vm';
-import { useEffect } from 'react';
+import { createRoot } from "react-dom/client";
+import { Wallet } from "./near-wallet";
+import { useInitNear, Widget } from "near-social-vm";
+import { useEffect } from "react";
 
-const wallet = new Wallet({network: 'testnet'});
+const wallet = new Wallet({ network: "testnet" });
 
 export default function Component({ src }) {
-
   const { initNear } = useInitNear();
 
   useEffect(() => {
-    initNear && initNear({ networkId: wallet.network, selector: wallet.selector });
+    initNear &&
+      initNear({ networkId: wallet.network, selector: wallet.selector });
   }, [initNear]);
 
   return (
     <div>
       <Widget src={src} />
-      <p className="mt-4 small"> <span class="text-secondary">Source:</span> <a href={`https://near.social/mob.near/widget/WidgetSource?src=${src}`}> {src} </a> </p>
+      <p class="mt-4 small">
+        <span class="text-secondary">Source:</span>
+        <a href={`https://near.social/mob.near/widget/WidgetSource?src=${src}`}>
+          {src}
+        </a>
+      </p>
     </div>
   );
 }
 
 window.onload = async () => {
   let isSignedIn = await wallet.startUp();
-  isSignedIn? signedInUI(): signedOutUI();
+  isSignedIn ? signedInUI() : signedOutUI();
 
-  const domNode = document.getElementById('components');
+  const domNode = document.getElementById("components");
   const root = createRoot(domNode);
   root.render(
-    <div className='row'>
-      <div className='col-6'>
-        <Component src='influencer.testnet/widget/HelloNear' />
-        <p class="my-2">&nbsp;</p>
-        <Component src='influencer.testnet/widget/LoveNear' />
+    <div className="row">
+      <div className="col-6">
+        <Component src="influencer.testnet/widget/HelloNear" />
+        <p className="my-2">&nbsp;</p>
+        <Component src="influencer.testnet/widget/LoveNear" />
       </div>
-      <div className='col-6'>
-        <Component src='influencer.testnet/widget/Lido' />      
+      <div className="col-6">
+        <Component src="influencer.testnet/widget/Lido" />
       </div>
     </div>
   );
 };
 
 // Button clicks
-document.querySelector('#sign-in-button').onclick = () => { wallet.signIn(); };
-document.querySelector('#sign-out-button').onclick = () => { wallet.signOut(); };
+document.querySelector("#sign-in-button").onclick = () => {
+  wallet.signIn();
+};
+document.querySelector("#sign-out-button").onclick = () => {
+  wallet.signOut();
+};
 
 // UI: Display the signed-out container
 function signedOutUI() {
-  document.querySelectorAll('#sign-out-button').forEach(el => el.style.display = 'none');
+  document
+    .querySelectorAll("#sign-out-button")
+    .forEach((el) => (el.style.display = "none"));
 }
 
 // UI: Displaying the signed in flow container and fill in account-specific data
 function signedInUI() {
-  document.querySelectorAll('#sign-in-button').forEach(el => el.style.display = 'none');
-  document.querySelectorAll('[data-behavior=account-id]').forEach(el => {
+  document
+    .querySelectorAll("#sign-in-button")
+    .forEach((el) => (el.style.display = "none"));
+  document.querySelectorAll("[data-behavior=account-id]").forEach((el) => {
     el.innerText = wallet.accountId;
   });
 }


### PR DESCRIPTION
## `class` prop bad use fix  

- fixed `class` vs `className` props incorrect use in the `nextjs templates`'s files
![image](https://github.com/near/create-near-app/assets/2791028/d104980e-7671-4ad4-9e9f-506f746099dd)

- changed `class` to `className` prop in: 
   - `templates/frontend/next-app/src/app/hello-components/page.js`
   - `templates/frontend/next-page/src/pages/hello-components/index.js` 
   - `templates/frontend/vanilla/src/components.js` files


_Note: Sorry for the double quotes it's my lint doing some messy trick I will try to fix it_