### PR TITLE
chore(ci): upgrade setup-node to v4

### DIFF
--- a/.github/workflows/test-contract-rs.yml
+++ b/.github/workflows/test-contract-rs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
         node-version: '22'
     - name: Install modules

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
         node-version: '22'
     - name: Install modules


### PR DESCRIPTION
Maintenance update to setup-node@v4 to align with the current best practices; nothing else modified. Refer to [v4.0.0 release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0) for details.